### PR TITLE
Fix #26: don't text search through date fields in coupon admin

### DIFF
--- a/saas/api/coupons.py
+++ b/saas/api/coupons.py
@@ -84,12 +84,12 @@ class SmartCouponListMixin(SearchableListMixin, SortableListMixin):
     """
     Subscriber list which is also searchable and sortable.
     """
-    search_fields = ['created_at',
-                     'code',
+    search_fields = ['code',
                      'description',
                      'percent',
-                     'ends_at',
                      'organization__full_name']
+
+    search_date_fields = ['created_at', 'ends_at']
 
     sort_fields_aliases = [('code', 'code'),
                            ('percent', 'percent'),


### PR DESCRIPTION
Supposedly, if the input filter text is parsed as a date, these searches should be usable, but I haven't figured out how to make that work yet. See also:
https://github.com/AndrewIngram/django-extra-views/blob/f4b1b9c31fa18e9cb57af062fc56c82176160910/extra_views/contrib/mixins.py#L86-89