### PR TITLE
Move download views into their own module

### DIFF
--- a/saas/templates/saas/subscriber_pipeline.html
+++ b/saas/templates/saas/subscriber_pipeline.html
@@ -22,7 +22,7 @@
                 <h2>Registered</h2>
                 <h2 ng-show="registered_loading">Please wait...</h2>
                 <p ng-hide="registered_loading">Total: [[registered.count]]</p>
-                <p ng-hide="registered loading"><a href="{% url 'saas_subscriber_pipeline_download' organization 'registered' %}?start_date=[[start_at]]&amp;end_date=[[ends_at]]">Download</a></p>
+                <p ng-hide="registered_loading"><a href="{% url 'saas_subscriber_pipeline_download' 'registered' %}?start_date=[[start_at]]&amp;end_date=[[ends_at]]">Download</a></p>
                 <ul ng-hide="registered_loading">
                     <li ng-repeat="organization in registered.registered" ng-cloak>
                         <a ng-if="organization.slug" href="{% url 'saas_profile' %}[[organization.slug]]/">[[organization.full_name]]</a>
@@ -35,7 +35,7 @@
                 <h2>Subscribed</h2>
                 <h2 ng-show="subscribed_loading">Please wait...</h2>
                 <p ng-hide="subscribed_loading">Total: [[subscribed.count]]</p>
-                <p ng-hide="registered loading"><a href="{% url 'saas_subscriber_pipeline_download' organization 'subscribed' %}?start_date=[[start_at]]&amp;end_date=[[ends_at]]">Download</a></p>
+                <p ng-hide="subscribed_loading"><a href="{% url 'saas_subscriber_pipeline_download' 'subscribed' %}?start_date=[[start_at]]&amp;end_date=[[ends_at]]">Download</a></p>
                 <ul ng-hide="subscribed_loading">
                     <li ng-repeat="organization in subscribed.subscribed" ng-cloak>
                         <a ng-if="organization.slug" class="[[endsSoon(organization)]]" href="{% url 'saas_profile' %}[[organization.slug]]/">[[organization.full_name]]</a>
@@ -49,7 +49,7 @@
                 <p>Total: [[churned.count]]</p>
                 <h2 ng-show="churned_loading"><i class="fa fa-refresh fa-spin"></i></h2>
                 <p ng-hide="churned_loading">Total: [[churned.count]]</p>
-                <p ng-hide="registered loading"><a href="{% url 'saas_subscriber_pipeline_download' organization 'churned' %}?start_date=[[start_at]]&amp;end_date=[[ends_at]]">Download</a></p>
+                <p ng-hide="churned_loading"><a href="{% url 'saas_subscriber_pipeline_download' 'churned' %}?start_date=[[start_at]]&amp;end_date=[[ends_at]]">Download</a></p>
                 <ul ng-hide="churned_loading">
                     <li ng-repeat="organization in churned.churned" ng-cloak>
                         <a ng-if="organization.slug" href="{% url 'saas_profile' %}[[organization.slug]]/">[[organization.full_name]]</a>

--- a/saas/urls/provider/__init__.py
+++ b/saas/urls/provider/__init__.py
@@ -33,6 +33,8 @@ urlpatterns = patterns('',
         include('saas.urls.provider.billing')),
     url(r'^metrics/',
         include('saas.urls.provider.metrics')),
+    url(r'^download/',
+        include('saas.urls.provider.download')),
     url(r'^',
         include('saas.urls.provider.profile')),
 )

--- a/saas/urls/provider/download.py
+++ b/saas/urls/provider/download.py
@@ -22,26 +22,21 @@
 # OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-'''Urls to metrics'''
+'''Urls to provider downloads'''
 
 from django.conf.urls import patterns, url
 
 from saas.settings import ACCT_REGEX
-from saas.views.metrics import (BalancesMetricsView,
-    CouponMetricsView, PlansMetricsView, RevenueMetricsView,
-    SubscriberPipelineView, UsageMetricsView)
+from saas.views.metrics import (BalancesDownloadView,
+    CouponMetricsDownloadView, SubscriberPipelineDownloadView)
 
 urlpatterns = patterns(
     'saas.views.metrics',
-    url(r'^usage/', UsageMetricsView.as_view(), name='saas_organization_usage'),
-    url(r'^pipeline/$',
-        SubscriberPipelineView.as_view(), name='saas_subscriber_pipeline'),
-    url(r'^plans/((?P<from_date>\d\d\d\d-\d\d)/)?',
-        PlansMetricsView.as_view(), name='saas_metrics_plans'),
-    url(r'^coupons/((?P<coupon>%s)/)?' % ACCT_REGEX,
-        CouponMetricsView.as_view(), name='saas_metrics_coupons'),
+    url(r'^pipeline/(?P<subscriber_type>[\w]+)$',
+        SubscriberPipelineDownloadView.as_view(),
+        name='saas_subscriber_pipeline_download'),
+    url(r'^coupons/', CouponMetricsDownloadView.as_view(),
+        name='saas_metrics_coupons_download'),
     url(r'^balances/',
-        BalancesMetricsView.as_view(), name='saas_metrics_balances'),
-    url(r'^',
-        RevenueMetricsView.as_view(), name='saas_metrics_summary'),
+        BalancesDownloadView.as_view(), name='saas_balances_download'),
 )

--- a/saas/views/metrics.py
+++ b/saas/views/metrics.py
@@ -101,11 +101,12 @@ class CouponMetricsDownloadView(ProviderMixin, View):
         csv_writer.writerow(self.headings)
         for cartitem in CartItem.objects.filter(coupon__in=coupons):
             csv_writer.writerow([
-                cartitem.coupon.code,
+                cartitem.coupon.code.encode('utf-8'),
                 cartitem.coupon.percent,
-                ' '.join([cartitem.user.first_name, cartitem.user.last_name]),
-                cartitem.user.email,
-                cartitem.plan,
+                ' '.join([cartitem.user.first_name, cartitem.user.last_name]).\
+                    encode('utf-8'),
+                cartitem.user.email.encode('utf-8'),
+                cartitem.plan.slug.encode('utf-8'),
             ])
         content.seek(0)
         resp = HttpResponse(content, content_type='text/csv')


### PR DESCRIPTION
This moves all the download views into their own download module, which also changes the URLconfs and URIs for the provider URLs. This works with the patch I just submitted to the private `djaodjin` testsite. 6b76ec2 isn't related to this PR; only 99bb745.