### PR TITLE
Update sorting defaults for subscriber admin list

### DIFF
--- a/saas/models.py
+++ b/saas/models.py
@@ -1534,7 +1534,8 @@ class TransactionManager(models.Manager):
             ((Q(orig_organization=organization)
               & Q(orig_account=transaction_type))
             | (Q(dest_organization=organization)
-              & Q(dest_account=transaction_type))))
+              & Q(dest_account=transaction_type)))) \
+            .order_by('-created_at')
 
 
     def by_customer(self, organization):
@@ -1546,7 +1547,8 @@ class TransactionManager(models.Manager):
              & (Q(dest_account=Transaction.PAYABLE) # Only customer side
                 | Q(dest_account=Transaction.EXPENSES)))
             |(Q(orig_organization=organization)
-              & Q(orig_account=Transaction.REFUNDED)))
+              & Q(orig_account=Transaction.REFUNDED))) \
+            .order_by('-created_at')
 
 
 class Transaction(models.Model):

--- a/saas/static/js/djaodjin-saas-angular.js
+++ b/saas/static/js/djaodjin-saas-angular.js
@@ -295,10 +295,10 @@ subscriptionControllers.controller('subscriptionListCtrl',
     ['$scope', '$http', '$timeout', 'Subscription', 'urls',
     function($scope, $http, $timeout, Subscription, urls) {
 
-    var defaultSortByField = 'organization';
+    var defaultSortByField = 'created_at';
     $scope.dir = {}
     $scope.totalItems = 0;
-    $scope.dir[defaultSortByField] = 'asc';
+    $scope.dir[defaultSortByField] = 'desc';
     $scope.params = {o: defaultSortByField, ot: $scope.dir[defaultSortByField]};
     $scope.subscriptions = Subscription.query($scope.params, function() {
         /* We cannot watch subscriptions.count otherwise things start


### PR DESCRIPTION
Fix #14 - changes the default sort column to the user's subscription date, and the default sort direction to reverse chronological. Clicking any other sort column still starts in ascending sort order - so, if a user switches to "Subscriber," and then back to "Since" (user's subscription creation date), results will be shown in ascending chronological order, unlike the default, when the page is first loaded. If this is a problem, we will need to define per-column default sorting orders.