### PR TITLE
Fix #41: refactor download views

### DIFF
--- a/saas/api/metrics.py
+++ b/saas/api/metrics.py
@@ -126,10 +126,7 @@ class OrganizationListAPIView(ProviderMixin, GenericAPIView):
             })
 
 
-
-class ChurnedAPIView(OrganizationListAPIView):
-
-    queryset_name = 'churned'
+class ChurnedQuerysetMixin(object):
 
     def get_range_queryset(self, start_time, end_time):
         return Organization.objects.filter(
@@ -139,9 +136,12 @@ class ChurnedAPIView(OrganizationListAPIView):
                 '-subscription__ends_at', 'full_name').distinct()
 
 
-class RegisteredAPIView(OrganizationListAPIView):
+class ChurnedAPIView(ChurnedQuerysetMixin, OrganizationListAPIView):
 
-    queryset_name = 'registered'
+    queryset_name = 'churned'
+
+
+class RegisteredQuerysetMixin(object):
 
     def get_range_queryset(self, start_time, end_time):
         #pylint: disable=unused-argument
@@ -152,9 +152,12 @@ class RegisteredAPIView(OrganizationListAPIView):
             ).order_by('-created_at', 'full_name').distinct()
 
 
-class SubscribedAPIView(OrganizationListAPIView):
+class RegisteredAPIView(RegisteredQuerysetMixin, OrganizationListAPIView):
 
-    queryset_name = 'subscribed'
+    queryset_name = 'registered'
+
+
+class SubscribedQuerysetMixin(object):
 
     def get_range_queryset(self, start_time, end_time):
         #pylint: disable=unused-argument
@@ -163,3 +166,8 @@ class SubscribedAPIView(OrganizationListAPIView):
             subscription__created_at__lt=end_time,
             subscription__ends_at__gte=end_time).order_by(
             'subscription__ends_at', 'full_name').distinct()
+
+
+class SubscribedAPIView(SubscribedQuerysetMixin, OrganizationListAPIView):
+
+    queryset_name = 'subscribed'

--- a/saas/api/transactions.py
+++ b/saas/api/transactions.py
@@ -83,7 +83,7 @@ class SmartTransactionListMixin(SearchableListMixin, SortableListMixin):
                            ('dest_amount', 'amount')]
 
 
-class TransactionListBaseAPIView(OrganizationMixin, ListAPIView):
+class TransactionQuerysetMixin(OrganizationMixin):
 
     def get_queryset(self):
         """
@@ -94,13 +94,13 @@ class TransactionListBaseAPIView(OrganizationMixin, ListAPIView):
 
 
 class TransactionListAPIView(SmartTransactionListMixin,
-                             TransactionListBaseAPIView):
+                             TransactionQuerysetMixin, ListAPIView):
 
     serializer_class = TransactionSerializer
     paginate_by = 25
 
 
-class TransferListBaseAPIView(ProviderMixin, ListAPIView):
+class TransferQuerysetMixin(ProviderMixin):
 
     def get_queryset(self):
         """
@@ -111,7 +111,8 @@ class TransferListBaseAPIView(ProviderMixin, ListAPIView):
             self.organization, Transaction.FUNDS)
 
 
-class TransferListAPIView(SmartTransactionListMixin, TransferListBaseAPIView):
+class TransferListAPIView(SmartTransactionListMixin, TransferQuerysetMixin,
+                          ListAPIView):
 
     serializer_class = TransactionSerializer
     paginate_by = 25

--- a/saas/templates/saas/subscriber_pipeline.html
+++ b/saas/templates/saas/subscriber_pipeline.html
@@ -22,7 +22,7 @@
                 <h2>Registered</h2>
                 <h2 ng-show="registered_loading">Please wait...</h2>
                 <p ng-hide="registered_loading">Total: [[registered.count]]</p>
-                <p ng-hide="registered_loading"><a href="{% url 'saas_subscriber_pipeline_download' 'registered' %}?start_date=[[start_at]]&amp;end_date=[[ends_at]]">Download</a></p>
+                <p ng-hide="registered_loading"><a href="{% url 'saas_subscriber_pipeline_download_registered' %}?start_date=[[start_at]]&amp;end_date=[[ends_at]]">Download</a></p>
                 <ul ng-hide="registered_loading">
                     <li ng-repeat="organization in registered.registered" ng-cloak>
                         <a ng-if="organization.slug" href="{% url 'saas_profile' %}[[organization.slug]]/">[[organization.full_name]]</a>
@@ -35,7 +35,7 @@
                 <h2>Subscribed</h2>
                 <h2 ng-show="subscribed_loading">Please wait...</h2>
                 <p ng-hide="subscribed_loading">Total: [[subscribed.count]]</p>
-                <p ng-hide="subscribed_loading"><a href="{% url 'saas_subscriber_pipeline_download' 'subscribed' %}?start_date=[[start_at]]&amp;end_date=[[ends_at]]">Download</a></p>
+                <p ng-hide="subscribed_loading"><a href="{% url 'saas_subscriber_pipeline_download_subscribed' %}?start_date=[[start_at]]&amp;end_date=[[ends_at]]">Download</a></p>
                 <ul ng-hide="subscribed_loading">
                     <li ng-repeat="organization in subscribed.subscribed" ng-cloak>
                         <a ng-if="organization.slug" class="[[endsSoon(organization)]]" href="{% url 'saas_profile' %}[[organization.slug]]/">[[organization.full_name]]</a>
@@ -49,7 +49,7 @@
                 <p>Total: [[churned.count]]</p>
                 <h2 ng-show="churned_loading"><i class="fa fa-refresh fa-spin"></i></h2>
                 <p ng-hide="churned_loading">Total: [[churned.count]]</p>
-                <p ng-hide="churned_loading"><a href="{% url 'saas_subscriber_pipeline_download' 'churned' %}?start_date=[[start_at]]&amp;end_date=[[ends_at]]">Download</a></p>
+                <p ng-hide="churned_loading"><a href="{% url 'saas_subscriber_pipeline_download_churned' %}?start_date=[[start_at]]&amp;end_date=[[ends_at]]">Download</a></p>
                 <ul ng-hide="churned_loading">
                     <li ng-repeat="organization in churned.churned" ng-cloak>
                         <a ng-if="organization.slug" href="{% url 'saas_profile' %}[[organization.slug]]/">[[organization.full_name]]</a>

--- a/saas/urls/provider/download.py
+++ b/saas/urls/provider/download.py
@@ -27,14 +27,22 @@
 from django.conf.urls import patterns, url
 
 from saas.views.metrics import (BalancesDownloadView,
-    CouponMetricsDownloadView, SubscriberPipelineDownloadView)
+    CouponMetricsDownloadView, SubscriberPipelineSubscribedDownloadView,
+    SubscriberPipelineRegisteredDownloadView,
+    SubscriberPipelineChurnedDownloadView)
 from saas.views.billing import TransferDownloadView
 
 urlpatterns = patterns(
     'saas.views.metrics',
-    url(r'^pipeline/(?P<subscriber_type>[\w]+)$',
-        SubscriberPipelineDownloadView.as_view(),
-        name='saas_subscriber_pipeline_download'),
+    url(r'^pipeline/registered/?',
+        SubscriberPipelineRegisteredDownloadView.as_view(),
+        name='saas_subscriber_pipeline_download_registered'),
+    url(r'^pipeline/subscribed/?',
+        SubscriberPipelineSubscribedDownloadView.as_view(),
+        name='saas_subscriber_pipeline_download_subscribed'),
+    url(r'^pipeline/churned/?',
+        SubscriberPipelineChurnedDownloadView.as_view(),
+        name='saas_subscriber_pipeline_download_churned'),
     url(r'^coupons/', CouponMetricsDownloadView.as_view(),
         name='saas_metrics_coupons_download'),
     url(r'^balances/',

--- a/saas/views/download.py
+++ b/saas/views/download.py
@@ -1,0 +1,37 @@
+'''
+CSV download view basics.
+'''
+
+import csv
+from StringIO import StringIO
+
+from django.http import HttpResponse
+from django.views.generic import View
+
+class CSVDownloadView(View):
+    def get(self, *args, **kwargs):
+        content = StringIO()
+        csv_writer = csv.writer(content)
+        csv_writer.writerow(self.get_headings())
+        for record in self.get_queryset():
+            csv_writer.writerow(self.queryrow_to_columns(record))
+        content.seek(0)
+        resp = HttpResponse(content, content_type='text/csv')
+        resp['Content-Disposition'] = \
+            'attachment; filename="{}"'.format(
+                self.get_filename())
+        return resp
+
+    def get_headings(self):
+        raise NotImplementedError
+
+    def get_queryset(self):
+        # Note: this should take the same arguments as for
+        # Searchable and SortableListMixin in "extra_views"
+        raise NotImplementedError
+
+    def get_filename(self):
+        raise NotImplementedError
+
+    def queryrow_to_columns(self, record):
+        raise NotImplementedError


### PR DESCRIPTION
Some design notes:

- `CSVDownloadView` is a direct descendant of `View` and defines hooks for providing information about the CSV to be generated (e.g. its filename, column headings, etc.)
- One of these hooks, `get_queryset`, coordinates with the `SearchableListMixin` and `SortableListMixin` from `extra_views`
- because this method is shared with outside code, we cannot change its signature - it can only take a single argument, `self`.
- some of these CSV hooks need information from the current request, like URL parameters or path components. Thus, implementors should define their own `get` that extracts necessary info, and then forward on the call via `super`.
- for consistency, all of the other hooks also only take a single argument (instead, say, of being forwarded `*args` and `**kwargs` from the `get` method, which would be less annoying)