### PR TITLE
Add organization dynamic roles

### DIFF
--- a/saas/admin.py
+++ b/saas/admin.py
@@ -26,7 +26,8 @@ from django.contrib import admin
 from django import forms
 
 from .models import (Agreement, CartItem, Charge, ChargeItem, Coupon,
-    Organization, Role, Plan, Signature, Subscription, Transaction)
+    Organization, Role, RoleDescription, Plan, Signature, Subscription,
+    Transaction)
 
 admin.site.register(Agreement)
 admin.site.register(CartItem)
@@ -35,6 +36,8 @@ admin.site.register(ChargeItem)
 admin.site.register(Coupon)
 admin.site.register(Organization)
 admin.site.register(Plan)
+admin.site.register(Role)
+admin.site.register(RoleDescription)
 admin.site.register(Signature)
 admin.site.register(Subscription)
 admin.site.register(Transaction)

--- a/saas/api/roles.py
+++ b/saas/api/roles.py
@@ -38,7 +38,7 @@ from ..compat import User
 from ..mixins import (OrganizationMixin, RelationMixin,
     RoleSmartListMixin, UserMixin)
 from ..models import Organization
-from ..utils import get_role_model
+from ..utils import get_role_model, normalize_role_name
 from .serializers import RoleSerializer
 
 
@@ -296,9 +296,7 @@ class RoleListAPIView(RelationListAPIView):
             raise Http404("No role named '%s'" % role_name)
 
     def get_queryset(self):
-        role_name = self.kwargs.get('role')
-        if role_name.endswith('s'):
-            role_name = role_name[:-1]
+        role_name = normalize_role_name(self.kwargs.get('role'))
         return get_role_model().objects.filter(
             Q(name=role_name) | Q(request_key__isnull=False),
             organization=self.organization)

--- a/saas/api/serializers.py
+++ b/saas/api/serializers.py
@@ -31,7 +31,7 @@ from ..compat import User
 from ..humanize import as_money
 from ..mixins import as_html_description, product_url
 from ..models import (BalanceLine, CartItem, Charge, Organization, Plan,
-    Subscription, Transaction)
+    RoleDescription, Subscription, Transaction)
 from ..utils import get_role_model
 
 #pylint: disable=no-init,old-style-class
@@ -216,13 +216,21 @@ class InvoicableSerializer(serializers.Serializer):
         raise RuntimeError('`update()` should not be called.')
 
 
-class RoleSerializer(serializers.ModelSerializer):
+class RoleDescriptionSerializer(serializers.ModelSerializer):
 
     organization = OrganizationSerializer(read_only=True)
+
+    class Meta:
+        model = RoleDescription
+        fields = ('created_at', 'name', 'slug', 'organization')
+
+
+class RoleSerializer(serializers.ModelSerializer):
+
+    role_description = RoleDescriptionSerializer(read_only=True)
     user = UserSerializer(read_only=True)
 
     class Meta:
         model = get_role_model()
-        fields = ('created_at', 'organization', 'user', 'name',
-            'request_key', 'grant_key')
-        read_only_fields = ('created_at', 'name', 'request_key', 'grant_key')
+        fields = ('created_at', 'role_description', 'user', 'request_key', 'grant_key')
+        read_only_fields = ('created_at', 'request_key', 'grant_key')

--- a/saas/decorators.py
+++ b/saas/decorators.py
@@ -42,7 +42,7 @@ from django.utils.decorators import available_attrs
 from . import settings
 from .models import (Charge, Organization, Plan, Signature, Subscription,
     get_broker)
-from .utils import datetime_or_now, get_roles
+from .utils import datetime_or_now, get_role_model
 
 
 LOGGER = logging.getLogger(__name__)
@@ -54,6 +54,7 @@ LOGGER = logging.getLogger(__name__)
 WEAK = 0
 NORMAL = 1
 STRONG = 2
+
 
 def _valid_role(user, candidates, role=settings.MANAGER):
     """
@@ -71,9 +72,10 @@ def _valid_role(user, candidates, role=settings.MANAGER):
         return candidates
     if user and user.is_authenticated():
         results = Organization.objects.filter(
-            pk__in=get_roles(role).filter(
-                user=user, organization__in=candidates).values(
-                'organization')).values('slug')
+            pk__in=get_role_model().objects.filter(role_description__slug=role,
+                                                   role_description__organization__in=candidates,
+                                                   user=user)
+                                           .values('role_description__organization')).values('slug')
     return results
 
 

--- a/saas/extras.py
+++ b/saas/extras.py
@@ -26,7 +26,7 @@ from django.contrib.auth import get_user_model
 from django.core.urlresolvers import NoReverseMatch, reverse
 from django.shortcuts import get_object_or_404
 
-from .utils import get_roles, get_organization_model
+from .utils import get_role_model, get_organization_model
 
 
 class OrganizationMixinBase(object):
@@ -42,8 +42,9 @@ class OrganizationMixinBase(object):
         # in django.conf.settings.
         from . import settings
         managers = get_user_model().objects.filter(
-            pk__in=get_roles(settings.MANAGER).filter(
-            organization=organization).values('user'))
+            pk__in=get_role_model().objects.filter(role_description__slug=settings.MANAGER,
+                                                   role_description__organization=organization)
+                                           .values('user'))
         if managers.count() == 1:
             manager = managers.get()
             if organization.slug == manager.username:
@@ -100,10 +101,8 @@ class OrganizationMixinBase(object):
                 pass
         else:
             urls['organization'].update({
-                'managers': reverse('saas_role_list',
-                    args=(organization, 'managers')),
-                'contributors': reverse('saas_role_list',
-                    args=(organization, 'contributors'))})
+                'roles': reverse('saas_role_list',
+                    args=(organization,))})
 
         if (organization.is_provider
             and self.request.user.is_authenticated()

--- a/saas/mixins.py
+++ b/saas/mixins.py
@@ -595,12 +595,13 @@ class RoleSmartListMixin(SortableListMixin,
     The queryset can be further filtered by passing a ``q`` parameter.
     The value in ``q`` will be matched against:
 
-      - organization.slug
-      - organization.full_name
-      - organization.email
+      - role_description.organization.slug
+      - role_description.organization.full_name
+      - role_description.organization.email
       - user.username
       - user.email
-      - name
+      - role_description.name
+      - role_description.slug
 
     The result queryset can be ordered by passing an ``o`` (field name)
     and ``ot`` (asc or desc) parameter.
@@ -611,16 +612,17 @@ class RoleSmartListMixin(SortableListMixin,
       - role_name
       - created_at
     """
-    search_fields = ['organization__slug',
-                     'organization__full_name',
-                     'organization__email',
+    search_fields = ['role_description__organization__slug',
+                     'role_description__organization__full_name',
+                     'role_description__organization__email',
                      'user__username',
                      'user__email',
-                     'name']
+                     'role_description__name',
+                     'role_description__slug']
 
-    sort_fields_aliases = [('full_name', 'organization__full_name'),
+    sort_fields_aliases = [('full_name', 'role_description__organization__full_name'),
                            ('username', 'user__username'),
-                           ('role_name', 'name'),
+                           ('role_name', 'role_description__name'),
                            ('created_at', 'created_at')]
 
 

--- a/saas/models.py
+++ b/saas/models.py
@@ -337,8 +337,6 @@ class Organization(models.Model):
         # an instance so the using database will be lost. The following
         # code saves the relation in the correct database associated
         # with the organization.
-        if role_name.endswith('s'):
-            role_name = role_name[:-1]
         queryset = get_roles(role_name, using=self._state.db).filter(
             organization=self, user=user)
         if not queryset.exists():

--- a/saas/models.py
+++ b/saas/models.py
@@ -690,6 +690,34 @@ class Organization(models.Model):
             self.save()
 
 
+class RoleDescription(models.Model):
+
+    created_at = models.DateTimeField(auto_now_add=True)
+    organization = models.ForeignKey(Organization, related_name="role_descriptions")
+    name = models.CharField(max_length=20)
+    slug = models.SlugField(help_text=_("Unique identifier shown in the URL bar."))
+
+    class Meta:
+        unique_together = ('organization', 'slug')
+
+    def __unicode__(self):
+        return '%s-%s' % (
+            unicode(self.slug),
+            unicode(self.organization))
+
+    def save(self, **kwargs):
+        if not self.slug:
+            self.slug = self.normalize_slug(slugify(self.name))
+        super(RoleDescription, self).save(**kwargs)
+
+    @staticmethod
+    def normalize_slug(slug):
+        slug = slug.lower()
+        if slug.endswith('s'):
+            slug = slug[:-1]
+        return slug
+
+
 class Role(models.Model):
 
     created_at = models.DateTimeField(auto_now_add=True)

--- a/saas/static/js/djaodjin-saas-angular.js
+++ b/saas/static/js/djaodjin-saas-angular.js
@@ -522,7 +522,7 @@ transactionControllers.controller("userRelationListCtrl",
         sortByField: "username",
         sortDirection: "desc",
         modalId: "#new-user-relation",
-        urls: {api_items: settings.urls.saas_api_user_relation_url,
+        urls: {api_items: settings.urls.saas_api_user_roles_url,
                api_candidates: settings.urls.api_users}}, settings);
     $controller("relationListCtrl", {
         $scope: $scope, $http: $http, $timeout:$timeout,

--- a/saas/templates/saas/base.html
+++ b/saas/templates/saas/base.html
@@ -15,11 +15,8 @@
       <a id="saas_provider_profile" href="{{urls.organization.profile}}">profile</a>
       | <a id="saas_billing_info" href="{{urls.organization.billing}}">billing</a>
       | <a id="saas_subscription_list" href="{{urls.organization.subscriptions}}">subscriptions</a>
-      {% if urls and urls.organization and urls.organization.managers %}
-      | <a id="saas_manager_list" href="{{urls.organization.managers}}">managers</a>
-      {% endif %}
-      {% if urls and urls.organization and urls.organization.contributors %}
-      | <a id="saas_contributor_list" href="{{urls.organization.contributors}}">contributors</a>
+      {% if urls and urls.organization and urls.organization.roles %}
+      | <a id="saas_role_list" href="{{urls.organization.roles}}">roles</a>
       {% endif %}
     </div>
     {% if organization.is_provider %}

--- a/saas/templates/saas/base_dashboard.html
+++ b/saas/templates/saas/base_dashboard.html
@@ -32,7 +32,7 @@ urls: {
     api_transactions: "{{saas_api_transactions}}",
 {% if urls.organization %}
 {% if urls.organization.api_roles %}
-    saas_api_user_relation_url: "{{ urls.organization.api_roles }}",
+    saas_api_user_roles_url: "{{ urls.organization.api_roles }}",
 {% endif %}
     /* subscriptions */
     api_organizations: "{{ urls.organization.api_profile_base }}",

--- a/saas/templates/saas/profile/roles.html
+++ b/saas/templates/saas/profile/roles.html
@@ -1,20 +1,21 @@
 {% extends "saas/base_dashboard.html" %}
 
-{% block saas_title %}{{role|capitalize}}{% endblock %}
+{% block saas_title %}Roles{% endblock %}
 
 {% block saas_content %}
-<section id="{{role}}" ng-app="saasApp">
+<section id="roles" ng-app="saasApp">
   <div ng-controller="userRelationListCtrl">
     <form>
       <input name="user" type="text" ng-model="item.slug" placeholder="Username or Email" />
       <input type="submit" ng-click="save($event)" />
     </form>
     <h2 ng-hide="items.$resolved">Please wait...</h2>
-    <h2 ng-show="items.$resolved && items.results.length == 0"><em>No {{role}} yet</em></h2>
+    <h2 ng-show="items.$resolved && items.results.length == 0"><em>No roles assigned yet</em></h2>
     <table ng-show="items.$resolved && items.results.length > 0">
       <thead>
         <tr>
           <th>Username</th>
+          <th>Role</th>
           <th>Email</th>
           <th></th>
         </tr>
@@ -22,6 +23,7 @@
       <tbody>
         <tr id="[[item.user.slug]]" ng-repeat="item in items.results" ng-cloak>
           <td>[[item.user.slug]]</td>
+          <td>[[item.role_description.name]]</td>
           <td>[[item.user.email]]</td>
           <td><button ng-click="remove($index)">Remove</button></td>
         </tr>
@@ -40,13 +42,13 @@ them.
                 name="message" maxlength="255" type="text" rows="10">
 Hello,
 
-I am adding you as a {{role}} to {{organization.printable_name}}.
+I am adding to {{organization.printable_name}}.
 
 Thank you,
 - {{request.user.first_name}}
       </textarea>
       <button id="new-rule-submit" ng-click="create($event)"
-              type="button">Invite {{role}}</button>
+              type="button">Invite user</button>
     </div>
   </div>
 </section>

--- a/saas/urls/api/provider/profile.py
+++ b/saas/urls/api/provider/profile.py
@@ -31,11 +31,21 @@ from django.conf.urls import url
 
 from ....api.plans import (PlanActivateAPIView, PlanCreateAPIView,
     PlanResourceView)
+from ....api.roles import RoleDescriptionAPIViewSet
 from ....api.organizations import SubscribersAPIView
 from ....settings import ACCT_REGEX
 
-
 urlpatterns = [
+    url(r'^profile/(?P<organization>%s)/role_descriptions/(?P<slug>%s)/?'
+        % (ACCT_REGEX, ACCT_REGEX),
+        RoleDescriptionAPIViewSet.as_view({'get': 'retrieve',
+                                           'put': 'update',
+                                           'patch': 'partial_update',
+                                           'delete': 'destroy'}),
+        name='saas_api_role_description_detail'),
+    url(r'^profile/(?P<organization>%s)/role_descriptions/?' % ACCT_REGEX,
+        RoleDescriptionAPIViewSet.as_view({'get': 'list', 'post': 'create'}),
+        name='saas_api_role_description_list'),
     url(r'^profile/(?P<organization>%s)/plans/(?P<plan>%s)/activate/'
         % (ACCT_REGEX, ACCT_REGEX),
         PlanActivateAPIView.as_view(), name='saas_api_plan_activate'),

--- a/saas/urls/api/subscriber/profile.py
+++ b/saas/urls/api/subscriber/profile.py
@@ -32,7 +32,7 @@ from ....api.organizations import (
     OrganizationDetailAPIView, OrganizationListAPIView)
 from ....api.subscriptions import (SubscriptionDetailAPIView,
     SubscriptionListAPIView)
-from ....api.roles import (RoleListAPIView, RoleDetailAPIView)
+from ....api.roles import (RoleListAPIView, RoleFilteredListAPIView, RoleDetailAPIView)
 from ....settings import ACCT_REGEX
 
 
@@ -40,9 +40,12 @@ urlpatterns = [
     url(r'^(?P<organization>%s)/roles/(?P<role>%s)/(?P<user>%s)/?'
         % (ACCT_REGEX, ACCT_REGEX, ACCT_REGEX),
         RoleDetailAPIView.as_view(), name='saas_api_role_detail'),
+    url(r'^(?P<organization>%s)/roles/?'
+        % (ACCT_REGEX),
+        RoleListAPIView.as_view(), name='saas_api_role_list'),
     url(r'^(?P<organization>%s)/roles/(?P<role>%s)/?'
         % (ACCT_REGEX, ACCT_REGEX),
-        RoleListAPIView.as_view(), name='saas_api_role_list'),
+        RoleFilteredListAPIView.as_view(), name='saas_api_role_filtered_list'),
     url(r'^(?P<organization>%s)/subscriptions/(?P<subscribed_plan>%s)/?'
         % (ACCT_REGEX, ACCT_REGEX),
         SubscriptionDetailAPIView.as_view(),

--- a/saas/urls/subscriber/profile.py
+++ b/saas/urls/subscriber/profile.py
@@ -32,8 +32,7 @@ from ...views.profile import (RoleListView, OrganizationProfileView,
     SubscriptionListView)
 
 urlpatterns = [
-    url(r'^profile/(?P<organization>%s)/roles/(?P<role>%s)/'
-        % (ACCT_REGEX, ACCT_REGEX),
+    url(r'^profile/(?P<organization>%s)/roles/$' % ACCT_REGEX,
         RoleListView.as_view(), name='saas_role_list'),
     url(r'^profile/(?P<organization>%s)/subscriptions/' % ACCT_REGEX,
         SubscriptionListView.as_view(), name='saas_subscription_list'),

--- a/saas/utils.py
+++ b/saas/utils.py
@@ -91,11 +91,15 @@ def get_role_model():
     return get_model_class(settings.ROLE_RELATION, 'ROLE_RELATION')
 
 
-def get_roles(role_name, using=None):
+def normalize_role_name(role_name):
     if role_name.endswith('s'):
         role_name = role_name[:-1]
+    return role_name
+
+
+def get_roles(role_name, using=None):
     return get_role_model().objects.db_manager(using=using).filter(
-        name=role_name)
+        name=normalize_role_name(role_name))
 
 
 def start_of_day(dtime_at=None):

--- a/saas/views/profile.py
+++ b/saas/views/profile.py
@@ -46,7 +46,7 @@ LOGGER = logging.getLogger(__name__)
 
 class RoleListView(OrganizationMixin, TemplateView):
     """
-    List of managers (or contributors) for an organization.
+    List of roles for an organization.
 
     Template:
 
@@ -67,11 +67,9 @@ class RoleListView(OrganizationMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super(RoleListView, self).get_context_data(**kwargs)
-        role = self.kwargs.get('role', None)
-        context.update({'role': role})
         urls_organization = {
             'api_roles': reverse(
-                'saas_api_role_list', args=(self.organization, role)),
+                'saas_api_role_list', args=(self.organization,)),
         }
         if 'urls' in context:
             if 'organization' in context['urls']:

--- a/testsite/fixtures/test_data.json
+++ b/testsite/fixtures/test_data.json
@@ -87,6 +87,51 @@
 },
 {
     "fields": {
+      "created_at": "2012-08-14T15:00:00-09:00",
+      "organization": 2,
+      "name": "Manager",
+      "slug": "manager"
+    },
+    "model" : "saas.RoleDescription", "pk": 1
+},
+{
+    "fields": {
+      "created_at": "2012-08-14T15:00:00-09:00",
+      "organization": 4,
+      "name": "Manager",
+      "slug": "manager"
+    },
+    "model" : "saas.RoleDescription", "pk": 2
+},
+{
+    "fields": {
+      "created_at": "2012-08-14T15:00:00-09:00",
+      "organization": 5,
+      "name": "Manager",
+      "slug": "manager"
+    },
+    "model" : "saas.RoleDescription", "pk": 3
+},
+{
+    "fields": {
+      "created_at": "2012-08-14T15:00:00-09:00",
+      "organization": 6,
+      "name": "Manager",
+      "slug": "manager"
+    },
+    "model" : "saas.RoleDescription", "pk": 4
+},
+{
+    "fields": {
+      "created_at": "2012-08-14T15:00:00-09:00",
+      "organization": 9,
+      "name": "Manager",
+      "slug": "manager"
+    },
+    "model" : "saas.RoleDescription", "pk": 5
+},
+{
+    "fields": {
       "date_joined": "2012-09-14T14:16:55-09:00",
       "email": "alice@localhost.localdomain",
       "first_name": "Alice",
@@ -95,7 +140,7 @@
       "is_superuser": true,
       "last_login": "2012-09-14T14:57:48-09:00",
       "last_name": "Doe",
-      "password": "pbkdf2_sha256$10000$z0MBiWn0Rlem$iZdC6uHomlE07qGK/TqfcfxNzKJtFp03c0JILF1frRc=", 
+      "password": "pbkdf2_sha256$10000$z0MBiWn0Rlem$iZdC6uHomlE07qGK/TqfcfxNzKJtFp03c0JILF1frRc=",
       "username": "alice"
     },
     "model": "auth.User", "pk": 2
@@ -103,8 +148,7 @@
 {
     "fields":{
       "created_at": "2012-10-01T00:00:00-09:00",
-      "name": "manager",
-      "organization": 2,
+      "role_description": 1,
       "user": 2
     },
     "model": "saas.Role", "pk": 2
@@ -127,7 +171,7 @@
       "is_superuser": true,
       "last_login": "2012-09-14T14:57:48-09:00",
       "last_name": "Manager",
-      "password": "pbkdf2_sha256$10000$z0MBiWn0Rlem$iZdC6uHomlE07qGK/TqfcfxNzKJtFp03c0JILF1frRc=", 
+      "password": "pbkdf2_sha256$10000$z0MBiWn0Rlem$iZdC6uHomlE07qGK/TqfcfxNzKJtFp03c0JILF1frRc=",
       "username": "donny"
     },
     "model": "auth.User", "pk": 3
@@ -135,11 +179,26 @@
 {
     "fields":{
       "created_at": "2012-10-01T00:00:00-09:00",
-      "name": "manager",
-      "organization": 2,
+      "role_description": 1,
       "user": 3
     },
     "model": "saas.Role", "pk": 3
+},
+{
+    "fields":{
+      "created_at": "2012-10-01T00:00:00-09:00",
+      "role_description": 2,
+      "user": 3
+    },
+    "model": "saas.Role", "pk": 10
+},
+{
+    "fields":{
+      "created_at": "2012-10-01T00:00:00-09:00",
+      "role_description": 5,
+      "user": 3
+    },
+    "model": "saas.Role", "pk": 11
 },
 {
     "fields": {
@@ -160,7 +219,7 @@
       "is_superuser": true,
       "last_login": "2012-09-14T14:57:48-09:00",
       "last_name": "Doe",
-      "password": "pbkdf2_sha256$10000$z0MBiWn0Rlem$iZdC6uHomlE07qGK/TqfcfxNzKJtFp03c0JILF1frRc=", 
+      "password": "pbkdf2_sha256$10000$z0MBiWn0Rlem$iZdC6uHomlE07qGK/TqfcfxNzKJtFp03c0JILF1frRc=",
       "user_permissions": [],
       "username": "xia"
     },
@@ -186,8 +245,7 @@
 {
     "fields":{
       "created_at": "2012-10-01T00:00:00-09:00",
-      "name": "manager",
-      "organization": 4,
+      "role_description": 2,
       "user": 4
     },
     "model": "saas.Role", "pk": 4
@@ -255,7 +313,7 @@
       "is_superuser": false,
       "last_login": "2015-02-01T00:00:00-09:00",
       "last_name": "DuJardin",
-      "password": "pbkdf2_sha256$10000$z0MBiWn0Rlem$iZdC6uHomlE07qGK/TqfcfxNzKJtFp03c0JILF1frRc=", 
+      "password": "pbkdf2_sha256$10000$z0MBiWn0Rlem$iZdC6uHomlE07qGK/TqfcfxNzKJtFp03c0JILF1frRc=",
       "username": "stephanie"
     },
     "model": "auth.User", "pk": 5
@@ -271,8 +329,7 @@
 {
     "fields": {
       "created_at": "2012-10-01T00:00:00-09:00",
-      "name": "manager",
-      "organization": 5,
+      "role_description": 3,
       "user": 5
     },
     "model": "saas.Role", "pk": 5
@@ -287,7 +344,7 @@
       "is_staff": false,
       "is_superuser": false,
       "last_login": "2014-01-01T00:00:00-00:00",
-      "password": "pbkdf2_sha256$10000$z0MBiWn0Rlem$iZdC6uHomlE07qGK/TqfcfxNzKJtFp03c0JILF1frRc=", 
+      "password": "pbkdf2_sha256$10000$z0MBiWn0Rlem$iZdC6uHomlE07qGK/TqfcfxNzKJtFp03c0JILF1frRc=",
       "username": "joe"
     },
     "model": "auth.User", "pk": 6
@@ -321,8 +378,7 @@
 {
     "fields": {
       "created_at": "2012-10-01T00:00:00-09:00",
-      "name": "manager",
-      "organization": 6,
+      "role_description": 4,
       "user": 6
     },
     "model": "saas.Role", "pk": 6
@@ -388,8 +444,7 @@
 {
     "fields": {
       "created_at": "2012-10-01T00:00:00-09:00",
-      "name": "manager",
-      "organization": 9,
+      "role_description": 5,
       "user": 9
     },
     "model": "saas.Role", "pk": 9


### PR DESCRIPTION
This add the new model `RoleDescription` as a class to contain information about a role and the organization it belongs (like Manager, Contributor, etc).

Users are assigned to roles using the `Role` model, but the `Role` class now has an FK to a `RoleDescription`, so we can relate the user to an organization.

### TODO

 * It's no longer possible to invite a user to a selected role.
 * Lack of a UI to manager `RoleDescription` instances (API and Admin are available though).
 * More test!