### PR TITLE
Changing settings org model

### DIFF
--- a/saas/migrations/0001_initial.py
+++ b/saas/migrations/0001_initial.py
@@ -18,6 +18,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        migrations.swappable_dependency(settings.SAAS_ORGANIZATION_MODEL),
     ]
 
     operations = [

--- a/saas/migrations/0001_initial.py
+++ b/saas/migrations/0001_initial.py
@@ -120,7 +120,7 @@ class Migration(migrations.Migration):
                 ('processor_pub_key', models.SlugField(blank=True, max_length=255, null=True)),
                 ('processor_refresh_token', models.SlugField(blank=True, max_length=255, null=True)),
                 ('extra', models.TextField(null=True, blank=True, help_text='Extra meta data (can be stringify JSON)')),
-                ('processor', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='processes', to='saas.Organization')),
+                ('processor', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='processes', to=settings.SAAS_ORGANIZATION_MODEL)),
                 ('picture', models.URLField(blank=True, help_text='URL location of the profile picture', max_length=2083, null=True, verbose_name='Profile picture')),
             ],
         ),
@@ -147,7 +147,7 @@ class Migration(migrations.Migration):
                 ('auto_renew', models.BooleanField(default=True)),
                 ('extra', models.TextField(null=True, help_text='Extra meta data (can be stringify JSON)')),
                 ('next_plan', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to='saas.Plan')),
-                ('organization', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='plans', to='saas.Organization')),
+                ('organization', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='plans', to=settings.SAAS_ORGANIZATION_MODEL)),
                 ('optin_on_request', models.BooleanField(default=False)),
                 ('skip_optin_on_grant', models.BooleanField(default=False)),
             ],
@@ -159,7 +159,7 @@ class Migration(migrations.Migration):
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('request_key', models.SlugField(blank=True, max_length=40, null=True)),
                 ('grant_key', models.SlugField(blank=True, max_length=40, null=True)),
-                ('organization', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='saas.Organization')),
+                ('organization', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.SAAS_ORGANIZATION_MODEL)),
             ],
         ),
         migrations.CreateModel(
@@ -170,7 +170,7 @@ class Migration(migrations.Migration):
                 ('name', models.CharField(max_length=20)),
                 ('slug', models.SlugField(help_text='Unique identifier shown in the URL bar.')),
                 ('extra', models.TextField(null=True)),
-                ('organization', models.ForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE, related_name='role_descriptions', to='saas.Organization')),
+                ('organization', models.ForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE, related_name='role_descriptions', to=settings.SAAS_ORGANIZATION_MODEL)),
             ],
         ),
         migrations.CreateModel(
@@ -191,7 +191,7 @@ class Migration(migrations.Migration):
                 ('ends_at', models.DateTimeField()),
                 ('description', models.TextField(blank=True, null=True)),
                 ('extra', models.TextField(null=True)),
-                ('organization', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='saas.Organization', related_name='subscriptions')),
+                ('organization', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.SAAS_ORGANIZATION_MODEL, related_name='subscriptions')),
                 ('plan', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='saas.Plan')),
             ],
         ),
@@ -208,8 +208,8 @@ class Migration(migrations.Migration):
                 ('dest_unit', models.CharField(default='usd', help_text='Measure of units on destination account', max_length=3)),
                 ('descr', models.TextField(default='N/A')),
                 ('event_id', models.SlugField(help_text='Event at the origin of this transaction (ex. job, charge, etc.)', null=True)),
-                ('dest_organization', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='incoming', to='saas.Organization')),
-                ('orig_organization', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='outgoing', to='saas.Organization')),
+                ('dest_organization', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='incoming', to=settings.SAAS_ORGANIZATION_MODEL)),
+                ('orig_organization', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='outgoing', to=settings.SAAS_ORGANIZATION_MODEL)),
             ],
         ),
         migrations.AddField(
@@ -230,7 +230,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='coupon',
             name='organization',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='saas.Organization'),
+            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.SAAS_ORGANIZATION_MODEL),
         ),
         migrations.AddField(
             model_name='coupon',
@@ -255,12 +255,12 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='charge',
             name='customer',
-            field=models.ForeignKey(help_text='organization charged', on_delete=django.db.models.deletion.CASCADE, to='saas.Organization'),
+            field=models.ForeignKey(help_text='organization charged', on_delete=django.db.models.deletion.CASCADE, to=settings.SAAS_ORGANIZATION_MODEL),
         ),
         migrations.AddField(
             model_name='charge',
             name='processor',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='charges', to='saas.Organization'),
+            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='charges', to=settings.SAAS_ORGANIZATION_MODEL),
         ),
         migrations.AddField(
             model_name='cartitem',

--- a/saas/migrations/0007_0_3_3.py
+++ b/saas/migrations/0007_0_3_3.py
@@ -27,12 +27,12 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='charge',
             name='customer',
-            field=models.ForeignKey(help_text='organization charged', on_delete=django.db.models.deletion.PROTECT, to='saas.Organization'),
+            field=models.ForeignKey(help_text='organization charged', on_delete=django.db.models.deletion.PROTECT, to=settings.SAAS_ORGANIZATION_MODEL),
         ),
         migrations.AlterField(
             model_name='charge',
             name='processor',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='charges', to='saas.Organization'),
+            field=models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='charges', to=settings.SAAS_ORGANIZATION_MODEL),
         ),
         migrations.AlterField(
             model_name='charge',
@@ -67,11 +67,11 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='transaction',
             name='dest_organization',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='incoming', to='saas.Organization'),
+            field=models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='incoming', to=settings.SAAS_ORGANIZATION_MODEL),
         ),
         migrations.AlterField(
             model_name='transaction',
             name='orig_organization',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='outgoing', to='saas.Organization'),
+            field=models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='outgoing', to=settings.SAAS_ORGANIZATION_MODEL),
         ),
     ]

--- a/saas/migrations/0008_0_3_4.py
+++ b/saas/migrations/0008_0_3_4.py
@@ -107,7 +107,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='charge',
             name='customer',
-            field=models.ForeignKey(help_text='Organization charged', on_delete=django.db.models.deletion.PROTECT, to='saas.Organization'),
+            field=models.ForeignKey(help_text='Organization charged', on_delete=django.db.models.deletion.PROTECT, to=settings.SAAS_ORGANIZATION_MODEL),
         ),
         migrations.AlterField(
             model_name='charge',
@@ -172,7 +172,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='coupon',
             name='organization',
-            field=models.ForeignKey(help_text='Coupon will only apply to purchased plans from this provider', on_delete=django.db.models.deletion.CASCADE, to='saas.Organization'),
+            field=models.ForeignKey(help_text='Coupon will only apply to purchased plans from this provider', on_delete=django.db.models.deletion.CASCADE, to=settings.SAAS_ORGANIZATION_MODEL),
         ),
         migrations.AlterField(
             model_name='coupon',
@@ -187,7 +187,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='role',
             name='organization',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='role', to='saas.Organization'),
+            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='role', to=settings.SAAS_ORGANIZATION_MODEL),
         ),
         migrations.AlterField(
             model_name='role',
@@ -242,7 +242,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='subscription',
             name='organization',
-            field=models.ForeignKey(help_text='Organization subscribed to the plan', on_delete=django.db.models.deletion.CASCADE, to='saas.Organization'),
+            field=models.ForeignKey(help_text='Organization subscribed to the plan', on_delete=django.db.models.deletion.CASCADE, to=settings.SAAS_ORGANIZATION_MODEL),
         ),
         migrations.AlterField(
             model_name='subscription',
@@ -272,7 +272,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='transaction',
             name='dest_organization',
-            field=models.ForeignKey(help_text='Target organization to which funds are deposited', on_delete=django.db.models.deletion.PROTECT, related_name='incoming', to='saas.Organization'),
+            field=models.ForeignKey(help_text='Target organization to which funds are deposited', on_delete=django.db.models.deletion.PROTECT, related_name='incoming', to=settings.SAAS_ORGANIZATION_MODEL),
         ),
         migrations.AlterField(
             model_name='transaction',
@@ -297,7 +297,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='transaction',
             name='orig_organization',
-            field=models.ForeignKey(help_text='Source organization from which funds are withdrawn', on_delete=django.db.models.deletion.PROTECT, related_name='outgoing', to='saas.Organization'),
+            field=models.ForeignKey(help_text='Source organization from which funds are withdrawn', on_delete=django.db.models.deletion.PROTECT, related_name='outgoing', to=settings.SAAS_ORGANIZATION_MODEL),
         ),
         migrations.AlterField(
             model_name='transaction',

--- a/saas/migrations/0015_0_11_1.py
+++ b/saas/migrations/0015_0_11_1.py
@@ -117,7 +117,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='plan',
             name='organization',
-            field=models.ForeignKey(help_text='Profile the plan belongs to', on_delete=django.db.models.deletion.CASCADE, related_name='plans', to='saas.organization'),
+            field=models.ForeignKey(help_text='Profile the plan belongs to', on_delete=django.db.models.deletion.CASCADE, related_name='plans', to=settings.SAAS_ORGANIZATION_MODEL),
         ),
         migrations.AlterField(
             model_name='plan',
@@ -177,16 +177,16 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='subscription',
             name='organization',
-            field=models.ForeignKey(help_text='Profile subscribed to the plan', on_delete=django.db.models.deletion.CASCADE, related_name='subscriptions', to='saas.organization'),
+            field=models.ForeignKey(help_text='Profile subscribed to the plan', on_delete=django.db.models.deletion.CASCADE, related_name='subscriptions', to=settings.SAAS_ORGANIZATION_MODEL),
         ),
         migrations.AlterField(
             model_name='transaction',
             name='dest_organization',
-            field=models.ForeignKey(help_text='Billing profile to which funds are deposited', on_delete=django.db.models.deletion.PROTECT, related_name='incoming', to='saas.organization'),
+            field=models.ForeignKey(help_text='Billing profile to which funds are deposited', on_delete=django.db.models.deletion.PROTECT, related_name='incoming', to=settings.SAAS_ORGANIZATION_MODEL),
         ),
         migrations.AlterField(
             model_name='transaction',
             name='orig_organization',
-            field=models.ForeignKey(help_text='Billing profile from which funds are withdrawn', on_delete=django.db.models.deletion.PROTECT, related_name='outgoing', to='saas.organization'),
+            field=models.ForeignKey(help_text='Billing profile from which funds are withdrawn', on_delete=django.db.models.deletion.PROTECT, related_name='outgoing', to=settings.SAAS_ORGANIZATION_MODEL),
         ),
     ]

--- a/saas/migrations/0015_0_11_1.py
+++ b/saas/migrations/0015_0_11_1.py
@@ -82,7 +82,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='organization',
             name='default_timezone',
-            field=models.CharField(default='America/Chicago', help_text='Timezone to use when reporting metrics', max_length=100),
+            field=models.CharField(default=settings.TIME_ZONE, help_text='Timezone to use when reporting metrics', max_length=100),
         ),
         migrations.AlterField(
             model_name='plan',

--- a/testsite/settings.py
+++ b/testsite/settings.py
@@ -319,3 +319,6 @@ else:
             'environment': 'testsite.jinja2.environment'
         }
     }]
+
+
+SAAS_ORGANIZATION_MODEL = "saas.Organization"


### PR DESCRIPTION
Editing all migrations to use `settings.SAAS_ORGANIZATION_MODEL` instead of `'saas.organization'` which will have no impact on the current project using saas package but will help future applications using the saas module not to have any inconsistent migrations due to the variation of names through the chain of the migration node tree.

Thanks to [Khalid](https://github.com/Khalidm98) who refer to this problem and the sol. too