### PR TITLE
[Work-in-Progress] Exclude personal profile from accessible API results

### DIFF
--- a/saas/api/roles.py
+++ b/saas/api/roles.py
@@ -305,10 +305,11 @@ class AccessibleByQuerysetMixin(UserMixin):
     def get_queryset(self):
         queryset = self.role_model.objects.filter(user=self.user)
 
-        include_personal_profile = self.request.GET.get('include_personal_profile', 'false').lower() == 'true'
-
+        truth_values = ['true', '1']
+        personal_params = self.request.query_params.get('include_personal_profile', '')
+        include_personal_profile = personal_params.lower() in truth_values
         if not include_personal_profile:
-            queryset = queryset.exclude(organization__slug=self.user.username)
+            queryset = queryset.exclude(organization__slug=self.user)
 
         return queryset
 

--- a/saas/api/roles.py
+++ b/saas/api/roles.py
@@ -303,7 +303,14 @@ class AccessibleByQuerysetMixin(UserMixin):
     role_model = get_role_model()
 
     def get_queryset(self):
-        return self.role_model.objects.filter(user=self.user)
+        queryset = self.role_model.objects.filter(user=self.user)
+
+        include_personal_profile = self.request.GET.get('include_personal_profile', 'false').lower() == 'true'
+
+        if not include_personal_profile:
+            queryset = queryset.exclude(organization__slug=self.user.username)
+
+        return queryset
 
 
 class AccessibleByDescrQuerysetMixin(AccessibleByQuerysetMixin):

--- a/saas/static/js/djaodjin-saas-vue.js
+++ b/saas/static/js/djaodjin-saas-vue.js
@@ -1504,6 +1504,7 @@ Vue.component('role-profile-list', {
             showRequested: false,
             params: {
                 role_status: "",
+                include_personal_profile: "1",
             },
         }
     },

--- a/saas/views/users.py
+++ b/saas/views/users.py
@@ -58,17 +58,12 @@ reference/djaoapp/latest/api/#listAccessibleBy>`__
     def get_context_data(self, **kwargs):
         context = super(ProductListView, self).get_context_data(**kwargs)
         user = self.user
-        api_accessibles_url = reverse(
-            'saas_api_accessibles', args=(user,)
-        )
-
-        # Append the query parameter to include the personal profile
-        api_accessibles_url += '?include_personal_profile=true'
 
         urls = {
             'api_candidates': reverse('saas_api_search_profiles'),
             'user': {
-                'api_accessibles': api_accessibles_url,
+                'api_accessibles': reverse(
+            'saas_api_accessibles', args=(user,)),
                 'api_profile_create': reverse(
                     'saas_api_user_profiles', args=(user,)),
             }}

--- a/saas/views/users.py
+++ b/saas/views/users.py
@@ -58,13 +58,19 @@ reference/djaoapp/latest/api/#listAccessibleBy>`__
     def get_context_data(self, **kwargs):
         context = super(ProductListView, self).get_context_data(**kwargs)
         user = self.user
+        api_accessibles_url = reverse(
+            'saas_api_accessibles', args=(user,)
+        )
+
+        # Append the query parameter to include the personal profile
+        api_accessibles_url += '?include_personal_profile=true'
+
         urls = {
             'api_candidates': reverse('saas_api_search_profiles'),
             'user': {
-                'api_accessibles': reverse(
-                    'saas_api_accessibles', args=(user,)),
+                'api_accessibles': api_accessibles_url,
                 'api_profile_create': reverse(
                     'saas_api_user_profiles', args=(user,)),
-        }}
+            }}
         update_context_urls(context, urls)
         return context


### PR DESCRIPTION
- Modified AccessibleByQuerysetMixin to exclude the authenticated user's personal profile from the results returned by the /api/users/{user}/accessibles endpoint. 
- The personal profile will continue to appear on the connected profiles page, but not in the API results. Done by using a query parameter. 
- Done by excluding organizations from the queryset that have the same slug as the user's username.