### PR TITLE
[Work-in-Progress] Separation of Personal Profile into Organization and User Account

### DIFF
--- a/saas/api/roles.py
+++ b/saas/api/roles.py
@@ -1445,14 +1445,13 @@ class UserProfileListAPIView(OrganizationSmartListMixin,
         if request.query_params.get('convert-from-personal') == '1':
             serializer = OrganizationUpdateSlugSerializer(data=request.data)
             serializer.is_valid(raise_exception=True)
-            accessed_user_slug = self.kwargs.get('user')
-            print(accessed_user_slug)
-            organization = get_object_or_404(get_organization_model(), slug=accessed_user_slug)
+            user_slug = self.kwargs.get('user')
+            organization = get_object_or_404(get_organization_model(), slug=user_slug)
 
             if not self.is_authorized_user(request.user, organization):
                 return Response({'error': 'Unauthorized'}, status=status.HTTP_403_FORBIDDEN)
 
-            if not self.is_valid_convert_to_organization_request(organization, accessed_user_slug):
+            if not self.is_valid_convert_to_organization_request(organization, user_slug):
                 return Response({'error': 'Invalid request.'}, status=status.HTTP_400_BAD_REQUEST)
 
             organization.slug = serializer.validated_data['new_slug']

--- a/saas/api/serializers.py
+++ b/saas/api/serializers.py
@@ -1289,14 +1289,3 @@ class RedeemCouponSerializer(NoModelSerializer):
 
     def create(self, validated_data):
         return validated_data
-
-class OrganizationUpdateSlugSerializer(OrganizationSerializer):
-    new_slug = serializers.SlugField(max_length=255)
-
-    def validate_new_slug(self, value):
-        if get_organization_model().objects.filter(slug=value).exists():
-            raise serializers.ValidationError("The slug already exists. Enter a different slug.")
-        return value
-
-    class Meta(OrganizationSerializer.Meta):
-        fields = OrganizationSerializer.Meta.fields + ('new_slug',)

--- a/saas/api/serializers.py
+++ b/saas/api/serializers.py
@@ -1289,3 +1289,14 @@ class RedeemCouponSerializer(NoModelSerializer):
 
     def create(self, validated_data):
         return validated_data
+
+class OrganizationUpdateSlugSerializer(OrganizationSerializer):
+    new_slug = serializers.SlugField(max_length=255)
+
+    def validate_new_slug(self, value):
+        if get_organization_model().objects.filter(slug=value).exists():
+            raise serializers.ValidationError("The slug already exists. Enter a different slug.")
+        return value
+
+    class Meta(OrganizationSerializer.Meta):
+        fields = OrganizationSerializer.Meta.fields + ('new_slug',)

--- a/saas/extras.py
+++ b/saas/extras.py
@@ -65,7 +65,6 @@ class OrganizationMixinBase(object):
 
     def get_context_data(self, **kwargs):
         context = super(OrganizationMixinBase, self).get_context_data(**kwargs)
-
         organization = self.organization
         if not organization:
             return context
@@ -81,6 +80,7 @@ class OrganizationMixinBase(object):
         # URLs for both sides (subscriber and provider).
         urls.update({
             'profile_base': reverse('saas_profile'),
+            'user_profiles': reverse('saas_api_user_profiles', args=(organization,)),
             'organization': {
                 'api_base': reverse(
                     'saas_api_organization', args=(organization,)),

--- a/saas/static/js/djaodjin-saas-vue.js
+++ b/saas/static/js/djaodjin-saas-vue.js
@@ -2154,8 +2154,7 @@ Vue.component('profile-update', {
             currentPicture: null,
             picture: null,
             codeSent: false,
-            showSlugInput: false,
-            newSlug: '',
+            profile_url: this.$urls.user_profiles,
         }
     },
     methods: {
@@ -2254,25 +2253,15 @@ Vue.component('profile-update', {
                 }
             });
         },
-            toggleSlugInput: function() {
-              this.showSlugInput = !this.showSlugInput;
-        },
-            convertToOrganization: function(username) {
-            var vm = this;
-            if (vm.showSlugInput) {
-                var payload = { new_slug: vm.newSlug };
-                vm.reqPost(`/api/users/${username}/profiles?convert-from-personal=1`, payload,
+            convertToOrganization: function() {
+              var vm = this;
+                vm.reqPost(vm.profile_url + `?convert-from-personal=1`, { full_name: vm.formFields.full_name },
                     function(resp) {
                         if (  resp.detail  ) {
                             vm.showMessages([resp.detail], "success");
                         }
-                        window.location.href = `/users/${username}/`;
                     }
                 );
-                vm.showSlugInput = false;
-            } else {
-                vm.showSlugInput = true;
-            }
         },
     },
     computed: {

--- a/saas/static/js/djaodjin-saas-vue.js
+++ b/saas/static/js/djaodjin-saas-vue.js
@@ -2153,7 +2153,9 @@ Vue.component('profile-update', {
             regions: regions,
             currentPicture: null,
             picture: null,
-            codeSent: false
+            codeSent: false,
+            showSlugInput: false,
+            newSlug: '',
         }
     },
     methods: {
@@ -2252,23 +2254,26 @@ Vue.component('profile-update', {
                 }
             });
         },
-            convertToOrganization: function(username, organizationSlug, csrfToken) {
-              var url = '/api/users/' + username + '/profiles/' + organizationSlug + '/';
-              fetch(url, {
-                method: 'POST',
-                headers: {
-                  'Content-Type': 'application/json',
-                  'X-CSRFToken': csrfToken
-                }
-              })
-              .then(response => response.json())
-              .then(data => {
-                window.location.href = '/profile/' + username + 'org/contact/';
-              })
-              .catch(error => {
-                console.error('Error converting to organization:', error);
-              });
+            toggleSlugInput: function() {
+              this.showSlugInput = !this.showSlugInput;
+        },
+            convertToOrganization: function(username) {
+            var vm = this;
+            if (vm.showSlugInput) {
+                var payload = { new_slug: vm.newSlug };
+                vm.reqPost(`/api/users/${username}/profiles?convert-from-personal=1`, payload,
+                    function(resp) {
+                        if (  resp.detail  ) {
+                            vm.showMessages([resp.detail], "success");
+                        }
+                        window.location.href = `/users/${username}/`;
+                    }
+                );
+                vm.showSlugInput = false;
+            } else {
+                vm.showSlugInput = true;
             }
+        },
     },
     computed: {
         imageSelected: function(){

--- a/saas/static/js/djaodjin-saas-vue.js
+++ b/saas/static/js/djaodjin-saas-vue.js
@@ -2251,7 +2251,24 @@ Vue.component('profile-update', {
                     vm.showMessages([resp.detail], "success");
                 }
             });
-        }
+        },
+            convertToOrganization: function(username, organizationSlug, csrfToken) {
+              var url = '/api/users/' + username + '/profiles/' + organizationSlug + '/';
+              fetch(url, {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/json',
+                  'X-CSRFToken': csrfToken
+                }
+              })
+              .then(response => response.json())
+              .then(data => {
+                window.location.href = '/profile/' + username + 'org/contact/';
+              })
+              .catch(error => {
+                console.error('Error converting to organization:', error);
+              });
+            }
     },
     computed: {
         imageSelected: function(){

--- a/saas/templates/saas/profile/index.html
+++ b/saas/templates/saas/profile/index.html
@@ -33,7 +33,8 @@
       </div>
     </div>
       {% if organization.slug == user.username %}
-        <button id="convert-to-organization" @click="convertToOrganization('{{user.username}}', '{{organization.slug}}', '{{csrf_token}}')">Convert to Organization</button>
+        <button @click="convertToOrganization('{{user.username}}')">Convert to Organization</button>
+        <input v-if="showSlugInput" v-model="newSlug" placeholder="Enter new slug">
       {% endif %}
   </div>
 </profile-update>

--- a/saas/templates/saas/profile/index.html
+++ b/saas/templates/saas/profile/index.html
@@ -32,6 +32,9 @@
         </div>
       </div>
     </div>
+      {% if organization.slug == user.username %}
+        <button id="convert-to-organization" @click="convertToOrganization('{{user.username}}', '{{organization.slug}}', '{{csrf_token}}')">Convert to Organization</button>
+      {% endif %}
   </div>
 </profile-update>
 {% endblock %}

--- a/saas/templates/saas/profile/index.html
+++ b/saas/templates/saas/profile/index.html
@@ -32,10 +32,11 @@
         </div>
       </div>
     </div>
-      {% if organization.slug == user.username %}
-        <button @click="convertToOrganization('{{user.username}}')">Convert to Organization</button>
-        <input v-if="showSlugInput" v-model="newSlug" placeholder="Enter new slug">
-      {% endif %}
+    {% if user.username == organization.slug %}
+    <button @click="convertToOrganization()">
+        Turn into an organization
+    </button>
+    {% endif %}
   </div>
 </profile-update>
 {% endblock %}

--- a/saas/urls/api/users.py
+++ b/saas/urls/api/users.py
@@ -28,7 +28,8 @@ URLs for API related to users accessible by.
 
 from ... import settings
 from ...api.roles import (AccessibleByListAPIView, AccessibleDetailAPIView,
-    RoleAcceptAPIView, AccessibleByDescrListAPIView, UserProfileListAPIView)
+                          RoleAcceptAPIView, AccessibleByDescrListAPIView, UserProfileListAPIView,
+                          ConvertToOrganizationView)
 from ...compat import path, re_path
 
 urlpatterns = [
@@ -46,4 +47,6 @@ urlpatterns = [
         AccessibleByListAPIView.as_view(), name='saas_api_accessibles'),
     path('users/<slug:user>/profiles',
         UserProfileListAPIView.as_view(), name='saas_api_user_profiles'),
+    path('users/<slug:user>/profiles/<slug:profile>/',
+         ConvertToOrganizationView.as_view(), name='saas_api_convert_to_organization')
 ]

--- a/saas/urls/api/users.py
+++ b/saas/urls/api/users.py
@@ -29,7 +29,7 @@ URLs for API related to users accessible by.
 from ... import settings
 from ...api.roles import (AccessibleByListAPIView, AccessibleDetailAPIView,
                           RoleAcceptAPIView, AccessibleByDescrListAPIView, UserProfileListAPIView,
-                          ConvertToOrganizationView)
+                          )
 from ...compat import path, re_path
 
 urlpatterns = [
@@ -47,6 +47,4 @@ urlpatterns = [
         AccessibleByListAPIView.as_view(), name='saas_api_accessibles'),
     path('users/<slug:user>/profiles',
         UserProfileListAPIView.as_view(), name='saas_api_user_profiles'),
-    path('users/<slug:user>/profiles/<slug:profile>/',
-         ConvertToOrganizationView.as_view(), name='saas_api_convert_to_organization')
 ]


### PR DESCRIPTION
Adds the ability to convert a personal profile organization into a separate organization by changing the slug of the organization by concatenating "org" to the end it. The feature can be accessed via a "Turn into an organization" button on the profile page, with corresponding functionality available through a new API endpoint.

Changes:
- `api/roles.py`: Created ConvertToOrganizationView to handle the backend logic including changing the slug of the organization.
- `saas/profile/index.html`: Added a button for the conversion on the profile page.
- `Djaodjin-saas-vue.js`: Implemented `convertToOrganization` method to connect the frontend to the API.
- `api/users.py`: Added URL routing for the new Convert to Organization endpoint.