### PR TITLE
[Work-in-Progress] Update report_weekly_revenue.py

### DIFF
--- a/saas/api/metrics.py
+++ b/saas/api/metrics.py
@@ -50,12 +50,13 @@ LOGGER = logging.getLogger(__name__)
 class BalancesAPIView(DateRangeContextMixin, ProviderMixin,
                       GenericAPIView):
     """
-    Retrieves deferred balances for various time periods.
-
-    Default: 12-month trailing table of revenue.
+    Retrieves 12-month trailing deferred balances
 
     Generate a table of revenue (rows) per months (columns) for a default
     balance sheet (Income, Backlog, Receivable).
+
+    Also supports other time periods to retrieve data for: hourly, daily,
+    weekly, yearly.
 
     **Tags**: chart, metrics, provider, transactionmodel
 
@@ -175,11 +176,12 @@ class BalancesAPIView(DateRangeContextMixin, ProviderMixin,
 class RevenueMetricAPIView(DateRangeContextMixin, ProviderMixin,
                            GenericAPIView):
     """
-    Retrieves trailing revenue data for various time periods.
-
-    Default: 12-month trailing data for sales, payments, and refunds.
+    Retrieves 12-month trailing revenue.
 
     Produces sales, payments and refunds over a period of time.
+
+    Also supports other time periods to retrieve data for: hourly, daily,
+    weekly, yearly.
 
     The API is typically used within an HTML
     `revenue page </docs/guides/themes/#dashboard_metrics_revenue>`_
@@ -413,9 +415,10 @@ class CouponUsesAPIView(CartItemSmartListMixin, CouponUsesQuerysetMixin,
 class CustomerMetricAPIView(DateRangeContextMixin, ProviderMixin,
                             GenericAPIView):
     """
-    Retrieves trailing customer count for various time periods.
+    Retrieves 12-month trailing customer counts.
 
-    Default: 12-month trailing customer count.
+    Also supports other time periods to retrieve data for: hourly, daily,
+    weekly, yearly.
 
     The API is typically used within an HTML
     `revenue page </docs/guides/themes/#dashboard_metrics_revenue>`_
@@ -628,9 +631,10 @@ class LifetimeValueMetricAPIView(LifetimeValueMetricMixin, ListAPIView):
 
 class PlanMetricAPIView(DateRangeContextMixin, ProviderMixin, GenericAPIView):
     """
-    Retrieves trailing plans performance for various time periods.
+    Retrieves 12-month trailing plans performance
 
-    Default: 12-month trailing data.
+    Also supports other time periods to retrieve data for: hourly, daily,
+    weekly, yearly.
 
     The API is typically used within an HTML
     `plans metrics page </docs/guides/themes/#dashboard_metrics_plans>`_

--- a/saas/api/metrics.py
+++ b/saas/api/metrics.py
@@ -136,9 +136,8 @@ class BalancesAPIView(DateRangeContextMixin, ProviderMixin,
     serializer_class = MetricsSerializer
     filter_backends = (DateRangeFilter,)
     queryset = Transaction.objects.all()
-    from drf_spectacular.utils import extend_schema
 
-    @extend_schema(request=PeriodSerializer)
+    @swagger_auto_schema(query_serializer=PeriodSerializer)
     def get(self, request, *args, **kwargs):
 
         #pylint: disable=unused-argument

--- a/saas/api/serializers.py
+++ b/saas/api/serializers.py
@@ -388,6 +388,20 @@ class ForceSerializer(NoModelSerializer):
         " not be found"))
 
 
+class PeriodSerializer(NoModelSerializer):
+
+    periods = serializers.ChoiceField(required=False,
+        choices=[choice[1].lower() for choice in
+                 Plan.INTERVAL_CHOICES],
+        default='monthly',
+        help_text=_("Set time granularity: 'hourly,' 'daily,' 'weekly,' "
+        "'monthly,' or 'yearly.' Default is 'monthly.'"))
+
+    num_periods = serializers.IntegerField(required=False,
+        min_value=1, help_text=_("Specify the number of periods to include. "
+        "Min value is 1."))
+
+
 class DatetimeValueTuple(serializers.ListField):
 
     child = serializers.CharField() # XXX (Datetime, Integer)

--- a/saas/management/commands/report_weekly_revenue.py
+++ b/saas/management/commands/report_weekly_revenue.py
@@ -58,19 +58,20 @@ class Command(BaseCommand):
         parser.add_argument(
             '--period', action='store',
             dest='period', default='weekly',
-            choices=[x[1].lower() for x in Plan.INTERVAL_CHOICES],
+            choices=[choice[1].lower() for choice in Plan.INTERVAL_CHOICES],
             help='Specifies the period to generate reports for'
         )
 
     @staticmethod
     def construct_date_periods(at_time, period='weekly', timezone=None):
+        # discarding time, keeping utc tzinfo (00:00:00 utc)
         tzinfo = parse_tz(timezone)
+
         def localize_time(time):
             # we are interested in 00:00 local time, if we don't have
             # local time zone, fall back to 00:00 utc time
             # in case we have local timezone, replace utc with it
             return tzinfo.localize(time.replace(tzinfo=None)) if tzinfo else time
-
 
         base_time = at_time.replace(
             minute=0 if period != 'yearly' else at_time.minute,

--- a/saas/management/commands/report_weekly_revenue.py
+++ b/saas/management/commands/report_weekly_revenue.py
@@ -25,7 +25,6 @@
 """Command for the cron job. Send revenue report for the last week"""
 
 import logging
-
 from dateutil.relativedelta import relativedelta, SU
 from django.core.management.base import BaseCommand
 
@@ -33,7 +32,7 @@ from ... import settings
 from ... import signals
 from ...humanize import as_money
 from ...metrics.base import (aggregate_transactions_by_period,
-    aggregate_transactions_change_by_period, get_different_units)
+                             aggregate_transactions_change_by_period, get_different_units)
 from ...models import Transaction
 from ...utils import datetime_or_now, get_organization_model, parse_tz
 
@@ -52,152 +51,196 @@ class Command(BaseCommand):
         parser.add_argument('--provider', action='append',
             dest='providers', default=None,
             help='Specifies provider to generate reports for.')
+        parser.add_argument('--period', action='store',
+            dest='period', default='weekly',
+            choices=['hourly', 'daily', 'weekly', 'monthly', 'yearly'],
+            help='Specifies the period to generate reports for')
 
     @staticmethod
-    def construct_date_periods(at_time, timezone=None):
+    def construct_date_periods(at_time, period='weekly', timezone=None):
         # discarding time, keeping utc tzinfo (00:00:00 utc)
-        today = at_time.replace(hour=0, minute=0, second=0, microsecond=0)
         tzinfo = parse_tz(timezone)
-        if tzinfo:
-            # we are interested in 00:00 local time, if we don't have
-            # local time zone, fall back to 00:00 utc time
-            # in case we have local timezone, replace utc with it
-            today = tzinfo.localize(today.replace(tzinfo=None))
-        if today.weekday() == SU:
-            last_sunday = today
-        else:
-            last_sunday = today + relativedelta(weeks=-1, weekday=SU)
-        prev_sunday = last_sunday - relativedelta(weeks=1)
 
-        prev_year = [
-            last_sunday + relativedelta(years=-1, weeks=-1, weekday=SU),
-            last_sunday + relativedelta(years=-1, weekday=SU)
-        ]
-        prev_week = [      # 2 consecutive weeks (last and previous)
-            prev_sunday - relativedelta(weeks=1),
-            prev_sunday,
-            last_sunday
-        ]
-        return prev_week, prev_year
+        def localize_time(time):
+            return tzinfo.localize(time.replace(tzinfo=None)) if tzinfo else time
+
+        base_time = at_time.replace(minute=0, second=0, microsecond=0)
+        current_time = localize_time(at_time)
+
+        normalization_rules = {
+            'daily': {'hour': 0},
+            'weekly': {'hour': 0},
+            'monthly': {'day': 1, 'hour': 0},
+            'yearly': {'month': 1, 'day': 1, 'hour': 0},
+        }
+        base_time = localize_time(base_time)
+        base_time = base_time.replace(**normalization_rules.get(period, {}))
+
+        prev_period, prev_year = None, None
+        if period == 'weekly':
+            last_sunday = base_time if base_time.weekday() == SU else (base_time
+                          + relativedelta(weeks=-1, weekday=SU))
+            prev_sunday = last_sunday - relativedelta(weeks=1)
+            prev_period = [prev_sunday - relativedelta(weeks=1),
+                           prev_sunday,
+                           last_sunday]
+            prev_year = [last_sunday + relativedelta(years=-1, weeks=-1, weekday=SU),
+                         last_sunday + relativedelta(years=-1, weekday=SU)]
+        elif period == 'yearly':
+            # For 'yearly' period:
+            # - 'prev_period' represents the time range starting from the first day of the previous year
+            #   up to the current time. If today is the first day of the year, it starts from today.
+            # - 'prev_year' represents the time range of the year before the 'prev_period'.
+            #
+            # For example, if today's date is 2023-09-06:
+            # - 'prev_period' would be [2022-01-01, 2023-01-01, 2023-09-06]
+            # - 'prev_year' would be [2021-01-01, 2022-01-01]
+            first_of_year = base_time if (base_time.month, base_time.day) == (1, 1) else (
+                            base_time.replace(month=1, day=1))
+            prev_year_start = first_of_year - relativedelta(years=1)
+            prev_period = [prev_year_start,
+                           first_of_year,
+                           current_time]
+            prev_year = [prev_year_start - relativedelta(years=1),
+                         prev_year_start]
+        elif period == 'monthly':
+            first_day_of_month = base_time if base_time.day == 1 else (
+                                base_time + relativedelta(months=-1, day=1))
+            prev_month = first_day_of_month - relativedelta(months=1)
+            prev_period = [prev_month - relativedelta(months=1),
+                           prev_month,
+                           first_day_of_month]
+            prev_year = [prev_month - relativedelta(years=1, months=1),
+                         prev_month - relativedelta(years=1)]
+        elif period == 'daily':
+            first_hour_of_day = base_time if base_time.hour == 0 else (
+                base_time + relativedelta(days=-1, hour=0)
+            )
+            prev_day = first_hour_of_day - relativedelta(days=1)
+            prev_period = [prev_day - relativedelta(days=1),
+                           prev_day,
+                           first_hour_of_day]
+            prev_year = [first_hour_of_day - relativedelta(years=1, days=1),
+                         first_hour_of_day - relativedelta(years=1)]
+        elif period == 'hourly':
+            first_min_of_hour = base_time if base_time.minute == 0 else (
+                                base_time + relativedelta(hours=-1))
+            prev_hour = first_min_of_hour - relativedelta(hours=1)
+            prev_period = [prev_hour - relativedelta(hours=1),
+                           prev_hour,
+                           first_min_of_hour]
+            prev_year = [first_min_of_hour - relativedelta(years=1, hours=1),
+                         first_min_of_hour - relativedelta(years=1)]
+
+        if period not in ['hourly', 'daily', 'weekly', 'monthly', 'yearly']:
+            return None, None
+
+        return prev_period, prev_year
 
     @staticmethod
     def construct_table(table, unit):
+        def calculate_percentage_change(current, previous):
+            try:
+                amount = (current - previous) * 100 / previous
+                percentage = str(round(amount, 2)) + '%'
+                if amount > 0:
+                    percentage = '+' + percentage
+                return percentage
+            except ZeroDivisionError:
+                return 'N/A'
         for row in table:
             val = row['values']
-            try:
-                amount = (val['last'] - val['prev']) * 100 / val['prev']
-                prev = str(round(amount, 2)) + '%'
-                if amount > 0:
-                    prev = '+' + prev
-            except ZeroDivisionError:
-                prev = 'N/A'
-            try:
-                amount = \
-                    (val['last'] - val['prev_year']) * 100 / val['prev_year']
-                prev_year = str(round(amount, 2)) + '%'
-                if amount > 0:
-                    prev_year = '+' + prev_year
-            except ZeroDivisionError:
-                prev_year = 'N/A'
+            val['prev'] = calculate_percentage_change(val['last'], val['prev'])
+            val['prev_year'] = calculate_percentage_change(val['last'], val['prev_year'])
             val['last'] = as_money(val['last'], unit)
-            val['prev'] = prev
-            val['prev_year'] = prev_year
         return table
 
     @staticmethod
-    def get_weekly_perf_data(provider, prev_week, prev_year):
+    def get_perf_data(provider, prev_periods, prev_year_periods, period_type):
         #pylint:disable=too-many-locals
-        account_table, _, _, table_unit = \
-            aggregate_transactions_change_by_period(provider,
-                Transaction.RECEIVABLE, account_title='Sales',
-                orig='orig', dest='dest',
-                date_periods=prev_week)
-        account_table_prev_year, _, _, _ = \
-            aggregate_transactions_change_by_period(provider,
-                Transaction.RECEIVABLE, account_title='Sales',
-                orig='orig', dest='dest',
-                date_periods=prev_year)
+        account_table, _, _, table_unit = aggregate_transactions_change_by_period(
+            provider, Transaction.RECEIVABLE, account_title='Sales',
+            orig='orig', dest='dest', date_periods=prev_periods
+        )
+        account_table_prev_year, _, _, _ = aggregate_transactions_change_by_period(
+            provider, Transaction.RECEIVABLE, account_title='Sales',
+            orig='orig', dest='dest', date_periods=prev_year_periods
+        )
 
-        _, payment_amounts, payments_unit = \
-            aggregate_transactions_by_period(
-                provider, Transaction.RECEIVABLE,
-                orig='dest', dest='dest',
-                orig_account=Transaction.BACKLOG,
-                orig_organization=provider,
-                date_periods=prev_week)
-        _, payment_amounts_prev_year, _ = \
-            aggregate_transactions_by_period(
-                provider, Transaction.RECEIVABLE,
-                orig='dest', dest='dest',
-                orig_account=Transaction.BACKLOG,
-                orig_organization=provider,
-                date_periods=prev_year)
+        _, payment_amounts, payments_unit = aggregate_transactions_by_period(
+            provider, Transaction.RECEIVABLE,
+            orig='dest', dest='dest', orig_account=Transaction.BACKLOG,
+            orig_organization=provider, date_periods=prev_periods
+        )
+        _, payment_amounts_prev_year, _ = aggregate_transactions_by_period(
+            provider, Transaction.RECEIVABLE,
+            orig='dest', dest='dest', orig_account=Transaction.BACKLOG,
+            orig_organization=provider, date_periods=prev_year_periods
+        )
 
-        _, refund_amounts, refund_unit = \
-            aggregate_transactions_by_period(
-                provider, Transaction.REFUND,
-                orig='dest', dest='dest',
-                date_periods=prev_week)
-        _, refund_amounts_prev_year, _ = \
-            aggregate_transactions_by_period(
-                provider, Transaction.REFUND,
-                orig='dest', dest='dest',
-                date_periods=prev_year)
+        _, refund_amounts, refund_unit = aggregate_transactions_by_period(
+            provider, Transaction.REFUND,
+            orig='dest', dest='dest', date_periods=prev_periods
+        )
+        _, refund_amounts_prev_year, _ = aggregate_transactions_by_period(
+            provider, Transaction.REFUND,
+            orig='dest', dest='dest', date_periods=prev_year_periods
+        )
 
         unit = settings.DEFAULT_UNIT
-
         units = get_different_units(table_unit, payments_unit, refund_unit)
 
         if len(units) > 1:
-            LOGGER.error("different units in get_weekly_perf_data: %s", units)
+            LOGGER.error("different units in get_%s_perf_data: %s", period_type, units)
 
         if units:
             unit = units[0]
-
         table = [{
             'slug': "Total Sales",
             'title': "Total Sales",
-             'values': {
+            'values': {
                 'last': account_table[0]['values'][1][1],
                 'prev': account_table[0]['values'][0][1],
                 'prev_year': account_table_prev_year[0]['values'][0][1]
             }}, {
-             'slug': "New Sales",
-             'title': "New Sales",
-             'values': {
+            'slug': "New Sales",
+            'title': "New Sales",
+            'values': {
                 'last': account_table[1]['values'][1][1],
                 'prev': account_table[1]['values'][0][1],
                 'prev_year': account_table_prev_year[1]['values'][0][1]
             }}, {
-             'slug': "Churned Sales",
-             'title': "Churned Sales",
-             'values': {
-                 'last': account_table[2]['values'][1][1],
+            'slug': "Churned Sales",
+            'title': "Churned Sales",
+            'values': {
+                'last': account_table[2]['values'][1][1],
                 'prev': account_table[2]['values'][0][1],
                 'prev_year': account_table_prev_year[2]['values'][0][1]
             }}, {
-             'slug': "Payments",
-             'title': "Payments",
-             'values': {
-                 'last': payment_amounts[1][1],
-                 'prev': payment_amounts[0][1],
-                 'prev_year': payment_amounts_prev_year[0][1]
+            'slug': "Payments",
+            'title': "Payments",
+            'values': {
+                'last': payment_amounts[1][1],
+                'prev': payment_amounts[0][1],
+                'prev_year': payment_amounts_prev_year[0][1]
             }}, {
-             'slug': "Refunds",
-             'title': "Refunds",
-             'values': {
+            'slug': "Refunds",
+            'title': "Refunds",
+            'values': {
                 'last': refund_amounts[1][1],
                 'prev': refund_amounts[0][1],
                 'prev_year': refund_amounts_prev_year[0][1]
             }}
         ]
-
         return (table, unit)
 
     def handle(self, *args, **options):
         # aware utc datetime object
         at_time = datetime_or_now(options.get('at_time'))
-        self.stdout.write("running report_weekly_revenue at %s" % at_time)
+        period = options.get('period', 'weekly')
+
+        self.stdout.write("running report_weekly_revenue for %s %s period at %s" %
+                          ('an' if period == 'hourly' else 'a', period, at_time))
 
         providers = get_organization_model().objects.filter(is_provider=True)
         provider_slugs = options.get('providers')
@@ -205,16 +248,28 @@ class Command(BaseCommand):
             providers = providers.filter(slug__in=provider_slugs)
         for provider in providers:
             dates = self.construct_date_periods(
-                at_time, timezone=provider.default_timezone)
-            prev_week, prev_year = dates
-            self.stdout.write("Two last consecutive weeks:\n  %s %s %s" % (
-                prev_week[0].isoformat(), prev_week[1].isoformat(),
-                prev_week[2].isoformat()))
-            self.stdout.write("Same week last year:\n"\
-                "                            %s %s" % (
-                prev_year[0].isoformat(), prev_year[1].isoformat()))
-            data, unit = self.get_weekly_perf_data(
-                provider, prev_week, prev_year)
+                at_time, period=period, timezone=provider.default_timezone)
+            prev_period, prev_year = dates
+            if period == 'yearly':
+                self.stdout.write(
+                    "Two last consecutive yearly periods\n: %s to %s and %s to %s" %
+                    (prev_period[0].isoformat(), prev_period[1].isoformat(), prev_period[1].isoformat(),
+                     prev_period[2].isoformat())
+                )
+                self.stdout.write(
+                    "Year before the corresponding yearly period\n: %s to %s" %
+                    (prev_year[0].isoformat(), prev_year[1].isoformat())
+                )
+            else:
+                self.stdout.write(
+                    "Two last consecutive %s periods\n: %s to %s and %s to %s" %
+                    (period, prev_period[0].isoformat(), prev_period[1].isoformat(),
+                     prev_period[1].isoformat(), prev_period[2].isoformat())
+                )
+                self.stdout.write(
+                    "Same %s period from the previous year\n: %s to %s" %
+                    (period, prev_year[0].isoformat(), prev_year[1].isoformat())
+                )
+            data, unit = self.get_perf_data(provider, prev_period, prev_year, period_type=period)
             table = self.construct_table(data, unit)
-            signals.weekly_sales_report_created.send(sender=__name__,
-                provider=provider, dates=dates, data=table)
+            signals.weekly_sales_report_created.send(sender=__name__, provider=provider, dates=dates, data=table)

--- a/saas/metrics/subscriptions.py
+++ b/saas/metrics/subscriptions.py
@@ -34,38 +34,43 @@ from .base import month_periods
 LOGGER = logging.getLogger(__name__)
 
 
-def active_subscribers(plan, from_date=None, tz=None):
+def active_subscribers(plan, from_date=None, tz=None, nb_months=12):
     """
     List of active subscribers for a *plan*.
     """
     #pylint:disable=invalid-name
     values = []
     for end_period in convert_dates_to_utc(month_periods(
-                            from_date=from_date, tz=tz)):
+                            nb_months=nb_months, from_date=from_date, tz=tz)):
         values.append([end_period,
             Subscription.objects.active_at(end_period, plan=plan).count()])
     return values
 
-def active_subscribers_by_period(plan, from_date=None, tz=None, period_func=None, periods=13):
+def active_subscribers_by_period(plan, from_date=None, tz=None, period_func=None,
+                                 num_periods=None):
     """
     List of active subscribers for a *plan* for a certain time period.
     """
     #pylint:disable=invalid-name
     values = []
-    for end_period in convert_dates_to_utc(period_func(
-                from_date=from_date, tz=tz, periods=periods)):
+    func_kwargs = {'from_date': from_date, 'tz': tz}
+    if num_periods:
+        func_kwargs['periods'] = num_periods
+
+    for end_period in convert_dates_to_utc(period_func(**func_kwargs)):
         values.append([end_period,
             Subscription.objects.active_at(end_period, plan=plan).count()])
     return values
 
 
-def churn_subscribers(plan=None, from_date=None, tz=None):
+def churn_subscribers(plan=None, from_date=None, tz=None, nb_months=12):
     """
     List of churn subscribers from the previous period for a *plan*.
     """
     #pylint:disable=invalid-name
     values = []
-    dates = convert_dates_to_utc(month_periods(13, from_date, tz=tz))
+    dates = convert_dates_to_utc(month_periods(nb_months=nb_months,
+                                               from_date=from_date, tz=tz))
     start_period = dates[0]
     kwargs = {}
     if plan:
@@ -76,13 +81,19 @@ def churn_subscribers(plan=None, from_date=None, tz=None):
         start_period = end_period
     return values
 
-def churn_subscribers_by_period(plan=None, from_date=None, tz=None, period_func=None):
+def churn_subscribers_by_period(plan=None, from_date=None, tz=None,
+                                period_func=None, num_periods=None):
     """
-    List of churn subscribers from the previous period for a *plan* for specific time periods.
+    List of churn subscribers from the previous period for a *plan* for specific time
+     periods.
     """
     #pylint:disable=invalid-name
     values = []
-    dates = convert_dates_to_utc(period_func(13, from_date, tz=tz))
+    func_kwargs = {'from_date': from_date, 'tz': tz}
+    if num_periods:
+        func_kwargs['periods'] = num_periods
+
+    dates = convert_dates_to_utc(period_func(**func_kwargs))
     start_period = dates[0]
     kwargs = {}
     if plan:

--- a/saas/metrics/subscriptions.py
+++ b/saas/metrics/subscriptions.py
@@ -46,6 +46,18 @@ def active_subscribers(plan, from_date=None, tz=None):
             Subscription.objects.active_at(end_period, plan=plan).count()])
     return values
 
+def active_subscribers_by_period(plan, from_date=None, tz=None, period_func=None, periods=13):
+    """
+    List of active subscribers for a *plan* for a certain time period.
+    """
+    #pylint:disable=invalid-name
+    values = []
+    for end_period in convert_dates_to_utc(period_func(
+                from_date=from_date, tz=tz, periods=periods)):
+        values.append([end_period,
+            Subscription.objects.active_at(end_period, plan=plan).count()])
+    return values
+
 
 def churn_subscribers(plan=None, from_date=None, tz=None):
     """
@@ -64,6 +76,22 @@ def churn_subscribers(plan=None, from_date=None, tz=None):
         start_period = end_period
     return values
 
+def churn_subscribers_by_period(plan=None, from_date=None, tz=None, period_func=None):
+    """
+    List of churn subscribers from the previous period for a *plan* for specific time periods.
+    """
+    #pylint:disable=invalid-name
+    values = []
+    dates = convert_dates_to_utc(period_func(13, from_date, tz=tz))
+    start_period = dates[0]
+    kwargs = {}
+    if plan:
+        kwargs = {'plan': plan}
+    for end_period in dates[1:]:
+        values.append([end_period, Subscription.objects.churn_in_period(
+            start_period, end_period, **kwargs).count()])
+        start_period = end_period
+    return values
 
 def subscribers_age(provider=None):
     if provider:

--- a/saas/mixins.py
+++ b/saas/mixins.py
@@ -46,6 +46,8 @@ from .utils import (build_absolute_uri, datetime_or_now,
     full_name_natural_split, get_organization_model, get_role_model,
     handle_uniq_error, update_context_urls, validate_redirect_url)
 from .extras import OrganizationMixinBase
+from .metrics.base import (hour_periods, day_periods, week_periods,
+                           month_periods, year_periods)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -599,6 +601,16 @@ class DateRangeContextMixin(object):
 
     forced_date_range = True
 
+    # A function-map that uses the older month_periods function
+    # and newer functions for the rest of the periods
+    PERIOD_FUNC_MAP = {
+        'monthly': month_periods,
+        'daily': day_periods,
+        'hourly': hour_periods,
+        'weekly': week_periods,
+        'yearly': year_periods
+    }
+
     @property
     def start_at(self):
         if not hasattr(self, '_start_at'):
@@ -630,6 +642,14 @@ class DateRangeContextMixin(object):
         if self.ends_at:
             context.update({'ends_at': self.ends_at})
         return context
+
+    @property
+    def period_func(self):
+        # Returns the period function from the request with a default
+        # set to month_periods
+        period = self.request.GET.get('period')
+        return self.PERIOD_FUNC_MAP.get(period, month_periods)
+
 
 
 class InvoicablesMixin(OrganizationMixin):

--- a/saas/mixins.py
+++ b/saas/mixins.py
@@ -650,6 +650,21 @@ class DateRangeContextMixin(object):
         period = self.request.GET.get('period')
         return self.PERIOD_FUNC_MAP.get(period, month_periods)
 
+    @property
+    def num_periods(self):
+        if not hasattr(self, '_num_periods'):
+            num_periods = self.request.GET.get('num_periods', None)
+            try:
+                # Keeping the maximum value of num_periods to 100
+                if num_periods and 0 < int(num_periods) < 100:
+                    self._num_periods = int(num_periods)
+                else:
+                    self._num_periods = None
+            except ValueError:
+                # In case a string or other non-integer values are
+                # passed in
+                self._num_periods = None
+        return self._num_periods
 
 
 class InvoicablesMixin(OrganizationMixin):

--- a/saas/signals.py
+++ b/saas/signals.py
@@ -93,6 +93,6 @@ subscription_request_accepted = Signal(
 subscription_request_created = Signal(
 #    providing_args=['subscription', 'reason']
 )
-weekly_sales_report_created = Signal(
+period_sales_report_created = Signal(
 #    providing_args=['provider', 'dates', 'data']
 )

--- a/saas/static/js/djaodjin-saas-angular.js
+++ b/saas/static/js/djaodjin-saas-angular.js
@@ -917,6 +917,7 @@ metricsControllers.controller("metricsCtrl",
             $scope.ends_at = $scope.ends_at.toDate();
         }
     }
+    $scope.period = 'monthly';
 
     // these aren't documented; do they do anything?
     $scope.formats = ["MMM dd, yyyy", "yyyy/MM/dd"];
@@ -961,7 +962,10 @@ metricsControllers.controller("metricsCtrl",
     };
 
     $scope.query = function(queryset) {
-        var params = {"ends_at": moment($scope.ends_at).format()};
+        var params = {
+            "ends_at": moment($scope.ends_at).format(),
+            "period": $scope.period,
+        };
         if( $scope.timezone !== 'utc' ) {
             params["timezone"] = moment.tz.guess();
         }
@@ -992,9 +996,10 @@ metricsControllers.controller("metricsCtrl",
         });
     };
 
-    $scope.prepareCurrentTabData = function(ends_at, timezone) {
+    $scope.prepareCurrentTabData = function(ends_at, timezone, period) {
         $scope.ends_at = ends_at;
         $scope.timezone = timezone;
+        $scope.period = period;
         $scope.refreshTable();
     };
 

--- a/saas/static/js/djaodjin-saas-vue.js
+++ b/saas/static/js/djaodjin-saas-vue.js
@@ -1561,6 +1561,7 @@ Vue.component('metrics-charts', {
             params: {
                 ends_at: this.datetimeOrNow(
                     this.$dateRange ? this.$dateRange.ends_at : null),
+                period: "monthly"
             },
         }
         return data;
@@ -1568,7 +1569,10 @@ Vue.component('metrics-charts', {
     methods: {
         fetchTableData: function(table, cb){
             var vm = this;
-            var params = {ends_at: vm.params.ends_at};
+            var params = {
+                ends_at: vm.params.ends_at,
+                period: vm.params.period,
+            };
             if( vm.timezone !== 'utc' ) {
                 params["timezone"] = vm.timezone;
             }
@@ -1689,7 +1693,16 @@ Vue.component('metrics-charts', {
                 this.$set(this.params, 'ends_at', this.asDateISOString(newVal));
                 this.get();
             }
+        },
+        period: {
+        get: function() {
+          return this.params.period;
+        },
+        set: function(newVal) {
+          this.$set(this.params, 'period', newVal);
+          this.get();
         }
+      },
     },
     mounted: function(){
         var vm = this;

--- a/saas/templates/saas/metrics/base.html
+++ b/saas/templates/saas/metrics/base.html
@@ -12,15 +12,25 @@
         <span>To</span>
         <input type="date"
            ng-model="ends_at"
-           ng-change="prepareCurrentTabData(ends_at, timezone)"
+           ng-change="prepareCurrentTabData(ends_at, timezone, period)"
            v-model="_ends_at"
            v-on:input="prepareCurrentTabData"></input>
         <select ng-model="timezone"
-              ng-change="prepareCurrentTabData(ends_at, timezone)"
+              ng-change="prepareCurrentTabData(ends_at, timezone, period)"
               v-model="timezone"
               @change="prepareCurrentTabData">
           <option value="local">Local</option>
           <option value="utc">UTC</option>
+        </select>
+        <select ng-model="period"
+                ng-change="prepareCurrentTabData(ends_at, timezone, period)"
+                v-model="period"
+                @change="prepareCurrentTabData">
+            <option value="hourly">Hourly</option>
+            <option value="daily">Daily</option>
+            <option value="weekly">Weekly</option>
+            <option value="monthly">Monthly</option>
+            <option value="yearly">Yearly</option>
         </select>
       </div>
     </div><!-- /choose report date -->


### PR DESCRIPTION
- Added `--period` command-line argument for specifying report time periods, with a default set to 'weekly'.
- Changed `construct_date_periods` to take a `period` argument to generate custom date ranges.
- Changed `get_weekly_perf_data` to `get_perf_data` and added a period argument to support different time spans.
- Changed the handle function to utilize the new `--period` argument and modified functions for generating reports.
- Made code structure adjustments to `construct_table` while keeping existing functionality intact.

Notes:
- Weekly report generation remains unchanged.
- Periods other than "yearly" start from the beginning of the specified period (e.g., Sunday for weekly, first of the month for monthly).
- For "yearly" reports, date range starts from the first day of the previous year to the current time. Can align this with the start-of-period logic used for other periods if preferred.