### PR TITLE
[Work-in-Progress] Added an API endpoint to retrieve subscribers with balances due - Issue #265

### DIFF
--- a/saas/api/serializers.py
+++ b/saas/api/serializers.py
@@ -1304,8 +1304,3 @@ class BalanceDueSerializer(OrganizationSerializer):
             'balance_due': subscription_data.get('balance', 0),
             'unit': subscription_data.get('unit', None)
         } for subscription_id, subscription_data in subscriptions.items()}
-
-    def to_representation(self, instance):
-        rep = super().to_representation(instance)
-        rep['balances_due'] = rep.pop('balances_due', {})
-        return rep

--- a/saas/api/serializers.py
+++ b/saas/api/serializers.py
@@ -1289,3 +1289,23 @@ class RedeemCouponSerializer(NoModelSerializer):
 
     def create(self, validated_data):
         return validated_data
+
+
+class BalanceDueSerializer(OrganizationSerializer):
+    balances_due = serializers.SerializerMethodField()
+
+    class Meta(OrganizationSerializer.Meta):
+        fields = OrganizationSerializer.Meta.fields + ('balances_due',)
+
+    def get_balances_due(self, obj):
+        balances_due = self.context.get('balances_due', {})
+        subscriptions = balances_due.get(obj.id, {})
+        return {subscription_id: {
+            'balance_due': subscription_data.get('balance', 0),
+            'unit': subscription_data.get('unit', None)
+        } for subscription_id, subscription_data in subscriptions.items()}
+
+    def to_representation(self, instance):
+        rep = super().to_representation(instance)
+        rep['balances_due'] = rep.pop('balances_due', {})
+        return rep

--- a/saas/mixins.py
+++ b/saas/mixins.py
@@ -1312,7 +1312,6 @@ class BalanceDueMixin(object):
     def get_balances_due(self, queryset, at_time):
         provider_subscriptions = Subscription.objects.filter(
             plan__organization=self.provider).values_list('id', flat=True)
-        print(provider_subscriptions)
         balances_due_by_subscription = {}
         non_zero_balance_ids = []
         for subscriber in queryset:
@@ -1320,7 +1319,6 @@ class BalanceDueMixin(object):
             # Get all balances for a subscriber
             all_balances = Transaction.objects.get_statement_balances(subscriber_id, until=at_time)
             total_due_by_subscription = {}
-            print(all_balances)
             for event_id, balance_data in six.iteritems(all_balances):
                 # Check whether the event belongs to self.provider
                 sub_id = int(event_id.split('_')[1].split('/')[0])

--- a/saas/urls/api/provider/subscribers.py
+++ b/saas/urls/api/provider/subscribers.py
@@ -32,7 +32,8 @@ from ....api.organizations import (EngagedSubscribersAPIView,
 from ....api.subscriptions import (ActiveSubscribersAPIView,
     AllSubscribersAPIView, ChurnedSubscribersAPIView, PlanAllSubscribersAPIView,
     PlanActiveSubscribersAPIView, PlanChurnedSubscribersAPIView,
-    PlanSubscriptionDetailAPIView, SubscriptionRequestAcceptAPIView)
+    PlanSubscriptionDetailAPIView, SubscriptionRequestAcceptAPIView,
+    SubscribersWithBalanceDueAPIView)
 from ....compat import path, re_path
 
 
@@ -82,4 +83,8 @@ urlpatterns = [
         settings.PROFILE_URL_KWARG,
         PlanActiveSubscribersAPIView.as_view(),
         name='saas_api_plan_subscribers'),
+    path('profile/<slug:%s>/subscribers/balance_due' %
+         settings.PROFILE_URL_KWARG,
+         SubscribersWithBalanceDueAPIView.as_view(),
+         name='saas_api_subscribers_with_balance_due')
 ]


### PR DESCRIPTION
- Added SubscribersWithBalanceDueAPIView that returns a list of subscribers with non-zero balances due for subscription to self.provider.
- Added BalanceDueMixin that deals with the logic of the API view.
- Added BalanceDueSerializer to include balance details.

Notes:
- BalanceDueSerializer: Inherits from OrganizationSerializer. Adds a new field, balances_due.

- BalanceDueMixin: Uses get_statement_balances for each subscriber to a provider, finds their balances, checks whether each balance is related to the provider(by checking if the plan's organization is self.provider.) There's room for optimization here because we're currently calling get_statement_balances on every single subscriber, whether they have a balance due or not.