### PR TITLE
Added API endpoint & page to retrieve customers with balances due - Issue #265

### DIFF
--- a/saas/api/metrics.py
+++ b/saas/api/metrics.py
@@ -824,16 +824,25 @@ class BalancesDueAPIView(BalancesDueMixin, ListAPIView):
                     "type": "organization",
                     "credentials": false,
                     "created_at": "2022-08-31T19:00:00-05:00",
-                    "balances_due": {
-                        "usd": {
-                            "contract_value": 94500,
+                    "balances": {
+                        "eur": {
+                            "contract_value": 1333,
                             "payments": 0,
-                            "balance_due": 94500
+                            "balance": 1333
+                        },
+                        "usd": {
+                            "contract_value": 982800,
+                            "cash_payments": 945000,
+                            "balance": 37800
                         }
-                    }
                 }
             ]
         }
     """
 
     serializer_class = BalancesDueSerializer
+
+    def paginate_queryset(self, queryset):
+        page = super(BalancesDueAPIView, self).paginate_queryset(
+            queryset)
+        return self.decorate_queryset(page if page else queryset)

--- a/saas/api/metrics.py
+++ b/saas/api/metrics.py
@@ -28,7 +28,7 @@ from rest_framework.generics import GenericAPIView, ListAPIView
 from rest_framework.response import Response
 
 from .serializers import (CartItemSerializer, LifetimeSerializer,
-    MetricsSerializer, PeriodSerializer)
+    MetricsSerializer, PeriodSerializer, BalancesDueSerializer)
 from .. import settings
 from ..compat import gettext_lazy as _, reverse, six
 from ..filters import DateRangeFilter
@@ -40,7 +40,7 @@ from ..metrics.subscriptions import (active_subscribers, churn_subscribers,
     subscribers_age, active_subscribers_by_period, churn_subscribers_by_period)
 from ..metrics.transactions import lifetime_value
 from ..mixins import (CartItemSmartListMixin, CouponMixin,
-    ProviderMixin, DateRangeContextMixin)
+    ProviderMixin, DateRangeContextMixin, BalancesDueMixin)
 from ..models import CartItem, Plan, Transaction
 from ..utils import convert_dates_to_utc, get_organization_model
 from ..docs import swagger_auto_schema
@@ -792,3 +792,48 @@ class PlanMetricAPIView(DateRangeContextMixin, ProviderMixin, GenericAPIView):
             'results': table,
             'extra': extra
         })
+
+class BalancesDueAPIView(BalancesDueMixin, ListAPIView):
+    """
+    Lists subscribers to a provider with a balance due
+
+    This endpoint returns a list of organizations with their respective
+    total contract value, payments made, and total balance due.
+
+    **Tags**: balance, provider, organization, subscribers
+
+    **Examples**
+
+    .. code-block:: http
+
+        GET /api/profile/cowork/due_balances HTTP/1.1
+
+    responds
+
+    .. code-block:: json
+
+        {
+            "count": 1,
+            "next": null,
+            "previous": null,
+            "results": [
+                {
+                    "slug": "xia",
+                    "printable_name": "Xia Lee",
+                    "picture": null,
+                    "type": "organization",
+                    "credentials": false,
+                    "created_at": "2022-08-31T19:00:00-05:00",
+                    "balances_due": {
+                        "usd": {
+                            "contract_value": 94500,
+                            "payments": 0,
+                            "balance_due": 94500
+                        }
+                    }
+                }
+            ]
+        }
+    """
+
+    serializer_class = BalancesDueSerializer

--- a/saas/api/serializers.py
+++ b/saas/api/serializers.py
@@ -1384,3 +1384,27 @@ class RedeemCouponSerializer(NoModelSerializer):
 
     def create(self, validated_data):
         return validated_data
+
+
+class BalancesDueSerializer(OrganizationSerializer):
+
+    balances_due = serializers.DictField(
+        child=serializers.IntegerField(),
+        help_text=_("Dictionary of balances due, keyed by unit"),
+        read_only=True)
+
+    class Meta(OrganizationSerializer.Meta):
+        fields = OrganizationSerializer.Meta.fields + ('balances_due',)
+
+    def to_representation(self, obj):
+        representation = super().to_representation(obj)
+        balances_due = self.context.get('balances_due', {})
+        customer = balances_due.get(obj.slug, {})
+        representation['balances_due'] = {
+            unit: {
+                'contract_value': val['contract_value'],
+                'payments': val['payments'],
+                'balance_due': val['balance'],
+            } for unit, val in six.iteritems(customer)
+        }
+        return representation

--- a/saas/api/serializers.py
+++ b/saas/api/serializers.py
@@ -1388,23 +1388,9 @@ class RedeemCouponSerializer(NoModelSerializer):
 
 class BalancesDueSerializer(OrganizationSerializer):
 
-    balances_due = serializers.DictField(
-        child=serializers.IntegerField(),
+    balances = serializers.DictField(
         help_text=_("Dictionary of balances due, keyed by unit"),
         read_only=True)
 
     class Meta(OrganizationSerializer.Meta):
-        fields = OrganizationSerializer.Meta.fields + ('balances_due',)
-
-    def to_representation(self, obj):
-        representation = super().to_representation(obj)
-        balances_due = self.context.get('balances_due', {})
-        customer = balances_due.get(obj.slug, {})
-        representation['balances_due'] = {
-            unit: {
-                'contract_value': val['contract_value'],
-                'payments': val['payments'],
-                'balance_due': val['balance'],
-            } for unit, val in six.iteritems(customer)
-        }
-        return representation
+        fields = OrganizationSerializer.Meta.fields + ('balances',)

--- a/saas/extras.py
+++ b/saas/extras.py
@@ -158,6 +158,8 @@ class OrganizationMixinBase(object):
                     'saas_metrics_lifetimevalue', args=(provider,)),
                 'ledger_balances': reverse(
                     'saas_balance', args=(provider,)),
+                'metrics_balances_due': reverse(
+                    'saas_metrics_balances_due', args=(provider,)),
                 'profile': reverse('saas_provider_profile'),
                 'subscribers': reverse(
                     'saas_subscriber_list', args=(provider,)),

--- a/saas/metrics/transactions.py
+++ b/saas/metrics/transactions.py
@@ -190,3 +190,121 @@ GROUP BY saas_organization.slug, saas_transaction.dest_unit
                     results[slug][unit].update(val)
 
     return results
+
+
+def get_balances_due(provider=None):
+    # pylint:disable=too-many-locals,too-many-statements
+    """
+    Calculates and returns the contract value, payments, and balance due
+    for each subscriber to a provider.
+    """
+
+    # Contract value (i.e. "Total Sales")
+    kwargs = {'orig_organization': provider} if provider else {}
+    contract_values = Transaction.objects.filter(
+        dest_account=Transaction.PAYABLE, **kwargs).values(
+        slug=F('dest_organization__slug')).annotate(
+        amount=Sum('orig_amount'), unit=F('orig_unit')).order_by(
+        'dest_organization__slug')
+    by_profiles = {}
+    for val in contract_values:
+        slug = val['slug']
+        unit = val['unit']
+        amount = val['amount']
+        if slug not in by_profiles:
+            by_profiles[slug] = {unit: {'contract_value': amount}}
+        else:
+            by_profiles[slug][unit] = {'contract_value': amount}
+
+    if provider:
+        provider_clause = "AND dest_organization_id = %d" % provider.pk
+    else:
+        provider_clause = ("AND NOT dest_organization_id IN (%d)" %
+                           settings.PROCESSOR_ID)
+
+    payments_query = """WITH transfers AS (
+  SELECT * FROM saas_transaction
+  WHERE orig_account='%(funds)s' AND
+    (dest_account='%(funds)s' OR dest_account='%(offline)s')
+    %(provider_clause)s),
+payments AS (
+  SELECT * FROM saas_transaction
+  WHERE orig_account='%(liability)s' AND
+    dest_account='%(funds)s' AND dest_organization_id IN %(processor_ids)s),
+matched_transfers_payments AS (
+  SELECT DISTINCT payments.event_id, payments.orig_organization_id,
+    payments.dest_unit, payments.dest_amount
+  FROM transfers
+  INNER JOIN payments
+    ON transfers.event_id = payments.event_id)
+SELECT saas_organization.slug, matched_transfers_payments.dest_unit,
+  SUM(matched_transfers_payments.dest_amount)
+FROM matched_transfers_payments
+INNER JOIN saas_organization
+  ON saas_organization.id = matched_transfers_payments.orig_organization_id
+GROUP BY saas_organization.slug, matched_transfers_payments.dest_unit""" % {
+        'provider_clause': provider_clause,
+        'processor_ids': '(%d)' % settings.PROCESSOR_ID,
+        'funds': Transaction.FUNDS,
+        'offline': Transaction.OFFLINE,
+        'liability': Transaction.LIABILITY
+    }
+
+    with connection.cursor() as cursor:
+        cursor.execute(payments_query, params=None)
+        for row in cursor.fetchall():
+            organization_slug = row[0]
+            unit = row[1]
+            amount = row[2]
+            account = Transaction.LIABILITY
+            if organization_slug not in by_profiles:
+                by_profiles[organization_slug] = {unit: {account: amount}}
+            else:
+                if unit not in by_profiles[organization_slug]:
+                    by_profiles[organization_slug].update({
+                        unit: {account: amount}})
+                else:
+                    by_profiles[organization_slug][unit].update({
+                        account: amount})
+
+    kwargs = {'dest_organization': provider} if provider else {}
+    refunds = Transaction.objects.filter(
+        dest_account=Transaction.REFUND,
+        orig_account=Transaction.REFUNDED, **kwargs).values(
+        slug=F('orig_organization__slug'), unit=F('orig_unit')).annotate(
+        amount=Sum('orig_amount')).order_by(
+        'orig_organization__slug')
+
+    for val in refunds:
+        organization_slug = val['slug']
+        unit = val['unit']
+        amount = val['amount']
+        account = Transaction.REFUNDED
+        if organization_slug not in by_profiles:
+            by_profiles[organization_slug] = {unit: {account: amount}}
+        else:
+            if unit not in by_profiles[organization_slug]:
+                by_profiles[organization_slug].update({unit: {account: amount}})
+            else:
+                by_profiles[organization_slug][unit].update({account: amount})
+
+    results = {}
+    for slug, by_units in six.iteritems(by_profiles):
+        for unit, val in six.iteritems(by_units):
+            contract_value = val.get('contract_value', 0)
+            payments = (val.get(Transaction.LIABILITY, 0)
+                        - val.get(Transaction.REFUNDED, 0))
+            balance = contract_value - payments if contract_value > payments else 0
+            val.update({
+                'contract_value': contract_value,
+                'payments': payments,
+                'balance': balance
+            })
+            if slug not in results:
+                results[slug] = {unit: val}
+            else:
+                if unit not in results[slug]:
+                    results[slug].update({unit: val})
+                else:
+                    results[slug][unit].update(val)
+    return results

--- a/saas/metrics/transactions.py
+++ b/saas/metrics/transactions.py
@@ -295,9 +295,11 @@ GROUP BY saas_organization.slug, matched_transfers_payments.dest_unit""" % {
             payments = (val.get(Transaction.LIABILITY, 0)
                         - val.get(Transaction.REFUNDED, 0))
             balance = contract_value - payments if contract_value > payments else 0
+            if balance < 1:
+                continue
             val.update({
                 'contract_value': contract_value,
-                'payments': payments,
+                'cash_payments': payments,
                 'balance': balance
             })
             if slug not in results:

--- a/saas/static/js/djaodjin-saas-vue.js
+++ b/saas/static/js/djaodjin-saas-vue.js
@@ -1784,11 +1784,6 @@ Vue.component('balancesdue-list', {
     mounted: function(){
         this.get();
     },
-    methods: {
-        getUnits: function(balances_due) {
-            return Object.keys(balances_due);
-        }
-    }
 });
 
 

--- a/saas/static/js/djaodjin-saas-vue.js
+++ b/saas/static/js/djaodjin-saas-vue.js
@@ -1772,6 +1772,25 @@ Vue.component('lifetimevalue-list', {
     }
 });
 
+Vue.component('balancesdue-list', {
+    mixins: [
+        itemListMixin
+    ],
+    data: function() {
+        return {
+            url: this.$urls.provider.api_metrics_balances_due
+        }
+    },
+    mounted: function(){
+        this.get();
+    },
+    methods: {
+        getUnits: function(balances_due) {
+            return Object.keys(balances_due);
+        }
+    }
+});
+
 
 Vue.component('plan-subscriber-list', {
     mixins: [

--- a/saas/templates/saas/metrics/balances_due.html
+++ b/saas/templates/saas/metrics/balances_due.html
@@ -1,0 +1,36 @@
+{% extends "saas/base_dashboard.html" %}
+
+{% block saas_title %}
+Balances due
+{% endblock %}
+
+{% block saas_content %}
+<balancesdue-list inline-template>
+  <div>
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Unit</th>
+          <th>Contract Value</th>
+          <th>Cash Payments</th>
+          <th>Balance Due</th>
+          <th>Created at</th>
+        </tr>
+      </thead>
+      <template v-for="(item, index) in items.results">
+        <tr v-for="unit in getUnits(item.balances_due)" :key="unit" :id="item.slug + '-' + unit" v-show="itemsLoaded && items.results.length > 0">
+          <td>
+            <a :href="'{{urls.profile_redirect}}' + item.slug + '/'">[[item.printable_name]]</a>
+          </td>
+          <td>[[unit]]</td>
+          <td>[[item.balances_due[unit].contract_value]]</td>
+          <td>[[item.balances_due[unit].payments]]</td>
+          <td>[[item.balances_due[unit].balance_due]]</td>
+          <td>[[item.created_at]]</td>
+        </tr>
+      </template>
+    </table>
+  </div>
+</balancesdue-list>
+{% endblock %}

--- a/saas/templates/saas/metrics/balances_due.html
+++ b/saas/templates/saas/metrics/balances_due.html
@@ -19,18 +19,19 @@ Balances due
         </tr>
       </thead>
       <template v-for="(item, index) in items.results">
-        <tr v-for="unit in getUnits(item.balances_due)" :key="unit" :id="item.slug + '-' + unit" v-show="itemsLoaded && items.results.length > 0">
+        <tr v-for="(balance, unit) in item.balances" :key="index + '-' + unit" v-show="itemsLoaded && items.results.length > 0">
           <td>
             <a :href="'{{urls.profile_redirect}}' + item.slug + '/'">[[item.printable_name]]</a>
           </td>
           <td>[[unit]]</td>
-          <td>[[item.balances_due[unit].contract_value]]</td>
-          <td>[[item.balances_due[unit].payments]]</td>
-          <td>[[item.balances_due[unit].balance_due]]</td>
+          <td>[[balance.contract_value]]</td>
+          <td>[[balance.cash_payments]]</td>
+          <td>[[balance.balance]]</td>
           <td>[[item.created_at]]</td>
         </tr>
       </template>
     </table>
+    {% include 'saas/_paginator.html' %}
   </div>
 </balancesdue-list>
 {% endblock %}

--- a/saas/templates/saas/metrics/revenue.html
+++ b/saas/templates/saas/metrics/revenue.html
@@ -7,4 +7,7 @@
 {% if urls.provider and urls.provider.ledger_balances %}
 <a id="balance-sheet" href="{{urls.provider.ledger_balances}}">Balance Sheet</a>
 {% endif %}
+{% if urls.provider and urls.provider.metrics_balances_due %}
+<a id="balances-due" href="{{urls.provider.metrics_balances_due}}">Balances Due</a>
+{% endif %}
 {% endblock %}

--- a/saas/urls/api/provider/metrics.py
+++ b/saas/urls/api/provider/metrics.py
@@ -55,7 +55,7 @@ urlpatterns = [
         settings.PROFILE_URL_KWARG,
         LifetimeValueMetricAPIView.as_view(),
         name='saas_api_metrics_lifetimevalue'),
-    path('metrics/<slug:%s>/balances_due' %
+    path('metrics/<slug:%s>/balances-due' %
          settings.PROFILE_URL_KWARG,
          BalancesDueAPIView.as_view(),
          name='saas_api_metrics_balances_due'),

--- a/saas/urls/api/provider/metrics.py
+++ b/saas/urls/api/provider/metrics.py
@@ -31,7 +31,7 @@ from ....api.federations import (FederatedSubscribersAPIView,
     SharedProfilesAPIView)
 from ....api.metrics import (BalancesAPIView, CouponUsesAPIView,
     CustomerMetricAPIView, LifetimeValueMetricAPIView, PlanMetricAPIView,
-    RevenueMetricAPIView)
+    RevenueMetricAPIView, BalancesDueAPIView)
 from ....compat import path
 
 
@@ -55,6 +55,10 @@ urlpatterns = [
         settings.PROFILE_URL_KWARG,
         LifetimeValueMetricAPIView.as_view(),
         name='saas_api_metrics_lifetimevalue'),
+    path('metrics/<slug:%s>/balances_due' %
+         settings.PROFILE_URL_KWARG,
+         BalancesDueAPIView.as_view(),
+         name='saas_api_metrics_balances_due'),
 
     # Metrics for a federation of providers
     path('metrics/<slug:%s>/federated/shared' %

--- a/saas/urls/views/provider/metrics.py
+++ b/saas/urls/views/provider/metrics.py
@@ -70,7 +70,7 @@ urlpatterns = [
         settings.PROFILE_URL_KWARG,
         SubscribersActivityView.as_view(),
         name='saas_subscribers_activity'),
-    path('metrics/<slug:%s>/balances_due' %
+    path('metrics/<slug:%s>/balances-due' %
          settings.PROFILE_URL_KWARG,
          BalancesDueView.as_view(),
          name='saas_metrics_balances_due')

--- a/saas/urls/views/provider/metrics.py
+++ b/saas/urls/views/provider/metrics.py
@@ -32,7 +32,8 @@ from ....views.download import CartItemDownloadView
 from ....views.profile import DashboardView
 from ....views.metrics import (SubscribersActivityView,
     CouponMetricsView, LifeTimeValueDownloadView,
-    LifeTimeValueMetricsView, PlansMetricsView, RevenueMetricsView)
+    LifeTimeValueMetricsView, PlansMetricsView, RevenueMetricsView,
+    BalancesDueView)
 
 
 urlpatterns = [
@@ -69,4 +70,8 @@ urlpatterns = [
         settings.PROFILE_URL_KWARG,
         SubscribersActivityView.as_view(),
         name='saas_subscribers_activity'),
+    path('metrics/<slug:%s>/balances_due' %
+         settings.PROFILE_URL_KWARG,
+         BalancesDueView.as_view(),
+         name='saas_metrics_balances_due')
 ]

--- a/saas/views/metrics.py
+++ b/saas/views/metrics.py
@@ -289,3 +289,29 @@ reference/djaoapp/latest/api/#listCustomerMetric>`__
                     args=(self.organization,))
             }])})
         return context
+
+class BalancesDueView(ProviderMixin, TemplateView):
+    """
+    Customers with balances due
+
+    Template:
+
+    To edit the layout of this page, create a local \
+    ``saas/metrics/balances_due.html`` (`example <https://github.com/djaodjin\
+/djaodjin-saas/tree/master/saas/templates/saas/metrics/balances_due.html>`__).
+
+    Template context:
+      - ``organization`` The provider object
+      - ``request`` The HTTP request object
+    """
+    template_name = 'saas/metrics/balances_due.html'
+
+    def get_context_data(self, **kwargs):
+        context = super(BalancesDueView, self).get_context_data(
+            **kwargs)
+        update_context_urls(context, {
+            'provider': {
+                'api_metrics_balances_due': reverse(
+                    'saas_api_metrics_balances_due', args=(self.provider,))}
+        })
+        return context


### PR DESCRIPTION
`saas/api/metrics.py`:

Added BalancesDueAPIView for balances due data.

`serializers.py`:
Added BalancesDueSerializer class extending OrganizationSerializer to include balances_due field.

`transactions.py`:
Added get_balances_due function to aggregate balance data per currency per subscriber, slightly different from the lifetime_value function which was overwriting currency units in the contract_values with the last currency unit:
`    by_profiles = {val['slug']: {val['unit']: {'contract_value': val['amount']}}
        for val in contract_values}
`
Removed deferred revenues.

`mixins.py`:

Added BalancesDueMixin. Decorates the queryset in order to be able to work with OrganizationSerializer.

`extras.py`:

Added metrics_balances_due URL to OrganizationMixinBase.

`djaodjin-saas-vue.js`:

Added balancesdue-list Vue component for fetching and rendering balance data on the front-end.

`balances_due.html`:

Created template to render the balances due table with a breakdown by currency units.

`revenue.html`:

Added link to the balances due page.

`urls/api/provider/metrics.py`:

Added URL pattern for BalancesDueAPIView.

`urls/views/provider/metrics.py`:

Added URL pattern for BalancesDueView.

`saas/views/metrics.py`:

Added BalancesDueView for rendering the front-end.