### PR TITLE
Validation to create plans with a minimum amount - Issue #279

### DIFF
--- a/saas/api/serializers.py
+++ b/saas/api/serializers.py
@@ -391,9 +391,8 @@ class ForceSerializer(NoModelSerializer):
 
 class PeriodSerializer(NoModelSerializer):
 
-    periods = serializers.ChoiceField(required=False,
-        choices=[choice[1].lower() for choice in
-                 Plan.INTERVAL_CHOICES],
+    period = EnumField(required=False,
+        choices=Plan.INTERVAL_CHOICES,
         default='monthly',
         help_text=_("Set time granularity: 'hourly,' 'daily,' 'weekly,' "
         "'monthly,' or 'yearly.' Default is 'monthly.'"))
@@ -756,6 +755,17 @@ class PlanCreateSerializer(PlanDetailSerializer):
 
     class Meta(PlanDetailSerializer.Meta):
         fields = PlanDetailSerializer.Meta.fields
+
+    def validate(self, data):
+        period_type = Plan.INTERVAL_CHOICES[data['period_type'] - 1][1]
+        period_amount = data.get('period_amount')
+
+        min_amount = getattr(settings, f'BROKER_MINIMUM_PLAN_AMOUNT_{period_type}', 0)
+        if period_amount < min_amount:
+            raise ValidationError(
+                f'Period amount must be at least {min_amount}.')
+
+        return data
 
 
 class OrganizationInviteSerializer(OrganizationCreateSerializer):

--- a/saas/settings.py
+++ b/saas/settings.py
@@ -80,7 +80,14 @@ _SETTINGS = {
             getattr(settings, 'BASE_DIR', "broker")),
         'IS_INSTANCE_CALLABLE': None,
         'BUILD_ABSOLUTE_URI_CALLABLE': None,
-        'FEE_PERCENTAGE': 0
+        'FEE_PERCENTAGE': 0,
+        'MINIMUM_PLAN_AMOUNT': {
+            'HOURLY': 0,
+            'DAILY': 0,
+            'WEEKLY': 0,
+            'MONTHLY': 0,
+            'YEARLY': 0,
+        }
     },
     'BYPASS_IMPLICIT_GRANT': {},
     'BYPASS_PERMISSION_CHECK': False,
@@ -147,6 +154,11 @@ AUTH_USER_MODEL = getattr(
 #: has its own database of users, profiles, etc.
 BROKER_CALLABLE = _SETTINGS.get('BROKER').get('GET_INSTANCE', None)
 BROKER_FEE_PERCENTAGE = _SETTINGS.get('BROKER').get('FEE_PERCENTAGE', 0)
+BROKER_MINIMUM_PLAN_AMOUNT_HOURLY = _SETTINGS.get('BROKER').get('MINIMUM_PLAN_AMOUNT', {}).get('HOURLY', 0)
+BROKER_MINIMUM_PLAN_AMOUNT_DAILY = _SETTINGS.get('BROKER').get('MINIMUM_PLAN_AMOUNT', {}).get('HOURLY', 0)
+BROKER_MINIMUM_PLAN_AMOUNT_WEEKLY = _SETTINGS.get('BROKER').get('MINIMUM_PLAN_AMOUNT', {}).get('HOURLY', 0)
+BROKER_MINIMUM_PLAN_AMOUNT_MONTHLY = _SETTINGS.get('BROKER').get('MINIMUM_PLAN_AMOUNT', {}).get('HOURLY', 0)
+BROKER_MINIMUM_PLAN_AMOUNT_YEARLY = _SETTINGS.get('BROKER').get('MINIMUM_PLAN_AMOUNT', {}).get('HOURLY', 0)
 
 #: overrides the implementation of `saas.utils.build_absolute_uri`
 #: This function must return fully qualified URL.


### PR DESCRIPTION
- `serializers.py`: Added validation in PeriodCreateSerializer to check whether the period_amount is greater than the minimum broker plan amount. Also updated PeriosSerializer to use an EnumField. 
- `settings.py`: Added variables for minimum plan amounts. 