### PR TITLE
[Work-in-Progress] Use serializers to validate query parameters & other changes

### DIFF
--- a/saas/api/billing.py
+++ b/saas/api/billing.py
@@ -44,7 +44,7 @@ from ..utils import datetime_or_now
 from .serializers import (CartItemSerializer, CartItemCreateSerializer,
     CartItemUploadSerializer, ChargeSerializer, CheckoutSerializer,
     OrganizationCartSerializer, RedeemCouponSerializer,
-    ValidationErrorSerializer)
+    ValidationErrorSerializer, QueryParamCartItemSerializer)
 
 
 LOGGER = logging.getLogger(__name__)
@@ -195,8 +195,12 @@ class CartItemAPIView(CartMixin, generics.CreateAPIView):
         #pylint:disable=unused-argument
         plan = None
         email = None
-        plan = request.query_params.get('plan')
-        email = request.query_params.get('email')
+        query_serializer = QueryParamCartItemSerializer(data=request.query_params)
+
+        if query_serializer.is_valid(raise_exception=True):
+            plan = query_serializer.validated_data.get('plan', None)
+            email = query_serializer.validated_data.get('email', None)
+
         self.destroy_in_session(request, plan=plan, email=email)
         if is_authenticated(request):
             # If the user is authenticated, we delete the cart items

--- a/saas/api/roles.py
+++ b/saas/api/roles.py
@@ -53,7 +53,8 @@ from .organizations import OrganizationDecorateMixin
 from .serializers import (AccessibleSerializer, ForceSerializer,
     OrganizationCreateSerializer,
     OrganizationDetailSerializer, RoleDescriptionSerializer,
-    AccessibleCreateSerializer, RoleCreateSerializer)
+    AccessibleCreateSerializer, RoleCreateSerializer,
+    QueryParamRoleStatusSerializer, QueryParamPersonalProfSerializer)
 
 
 LOGGER = logging.getLogger(__name__)
@@ -196,7 +197,10 @@ class ListOptinAPIView(OrganizationDecorateMixin, OrganizationCreateMixin,
                         organizations = [
                             self.create_organization(organization_data)]
             if not organizations:
-                if not request.GET.get('force', False):
+                query_serializer = ForceSerializer(data=self.request.query_params)
+                query_serializer.is_valid(raise_exception=True)
+                force = query_serializer.validated_data.get('force', False)
+                if not force:
                     raise Http404(_("Profile %(organization)s does not exist."
                     ) % {'organization': slug})
                 if not email:
@@ -275,7 +279,10 @@ class InvitedRequestedListMixin(object):
         # here instead of later in RoleInvitedListMixin.
         self.request.invited_count = queryset.filter(
             grant_key__isnull=False).count()
-        role_status = self.request.query_params.get('role_status', '')
+        query_serializer = QueryParamRoleStatusSerializer(data=self.request.query_params)
+        role_status = ''
+        if query_serializer.is_valid(raise_exception=True):
+            role_status = query_serializer.validated_data.get('role_status', '')
         stts = role_status.split(',')
         flt = None
         if 'active' in stts:
@@ -304,11 +311,12 @@ class AccessibleByQuerysetMixin(UserMixin):
 
     def get_queryset(self):
         queryset = self.role_model.objects.filter(user=self.user)
+        query_serializer = QueryParamPersonalProfSerializer(data=self.request.query_params)
+        include_personal_profile = ''
 
-        truth_values = ['true', '1']
-        personal_params = self.request.query_params.get(
-            'include_personal_profile', '')
-        include_personal_profile = personal_params.lower() in truth_values
+        if query_serializer.is_valid(raise_exception=True):
+            include_personal_profile = query_serializer.validated_data.get(
+                'include_personal_profile', '')
         if not include_personal_profile:
             queryset = queryset.exclude(organization__slug=self.user)
 
@@ -924,7 +932,12 @@ class RoleByDescrQuerysetMixin(RoleDescriptionMixin, RoleQuerysetBaseMixin):
         self.request.invited_count = queryset.filter(
             role_description=self.role_description,
             grant_key__isnull=False).count()
-        role_status = self.request.query_params.get('role_status', '')
+
+        query_serializer = QueryParamRoleStatusSerializer(data=self.request.query_params)
+        role_status = None
+        if query_serializer.is_valid(raise_exception=True):
+            role_status = query_serializer.validated_data.get('role_status', '')
+
         stts = role_status.split(',')
         flt = (Q(role_description=self.role_description) |
             Q(request_key__isnull=False))
@@ -1025,7 +1038,10 @@ class RoleByDescrListAPIView(RoleSmartListMixin, RoleByDescrQuerysetMixin,
             except user_model.DoesNotExist:
                 user = None
         if not user:
-            if not request.GET.get('force', False):
+            query_serializer = ForceSerializer(data=self.request.query_params)
+            query_serializer.is_valid(raise_exception=True)
+            force = query_serializer.validated_data.get('force', False)
+            if not force:
                 sep = ""
                 not_found_msg = "Cannot find"
                 if serializer.validated_data.get('slug'):
@@ -1469,9 +1485,12 @@ class UserProfileListAPIView(OrganizationSmartListMixin,
         validated_data = dict(serializer.validated_data)
 
         # If we're creating an organization from a personal profile
-        if request.query_params.get('convert-from-personal') == '1':
-            organization = self.get_queryset().filter(slug__exact=self.user.username).first()
+        query_serializer = QueryParamPersonalProfSerializer(data=request.query_params)
+        query_serializer.is_valid(raise_exception=True)
+        convert_from_personal = query_serializer.validated_data.get('convert_from_personal', False)
 
+        if convert_from_personal:
+            organization = self.get_queryset().filter(slug__exact=self.user.username).first()
             if not self.is_valid_convert_to_organization_request(organization):
                 return Response({'error': _('Invalid request.')}, status=status.HTTP_400_BAD_REQUEST)
 
@@ -1481,20 +1500,21 @@ class UserProfileListAPIView(OrganizationSmartListMixin,
 
             return Response({"detail": _("Successfully converted personal profile to organization.")},
                             status=status.HTTP_200_OK)
-        if 'email' not in validated_data:
-            # email is optional to create the profile but it is required
-            # to save the record in the database.
-            validated_data.update({'email': request.user.email})
-        if 'full_name' not in validated_data:
-            # full_name is optional to create the profile but it is required
-            # to save the record in the database.
-            validated_data.update({'full_name': ""})
+        else:
+            if 'email' not in validated_data:
+                # email is optional to create the profile but it is required
+                # to save the record in the database.
+                validated_data.update({'email': request.user.email})
+            if 'full_name' not in validated_data:
+                # full_name is optional to create the profile but it is required
+                # to save the record in the database.
+                validated_data.update({'full_name': ""})
 
-        # creates profile
-        with transaction.atomic():
-            organization = self.create_organization(validated_data)
-            organization.add_manager(self.user)
-        self.decorate_personal(organization)
+            # creates profile
+            with transaction.atomic():
+                organization = self.create_organization(validated_data)
+                organization.add_manager(self.user)
+            self.decorate_personal(organization)
 
         # returns created profile
         serializer = self.serializer_class(

--- a/saas/mixins.py
+++ b/saas/mixins.py
@@ -46,8 +46,6 @@ from .utils import (build_absolute_uri, datetime_or_now,
     full_name_natural_split, get_organization_model, get_role_model,
     handle_uniq_error, update_context_urls, validate_redirect_url)
 from .extras import OrganizationMixinBase
-from .metrics.base import (hour_periods, day_periods, week_periods,
-                           month_periods, year_periods)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -601,16 +599,6 @@ class DateRangeContextMixin(object):
 
     forced_date_range = True
 
-    # A function-map that uses the older month_periods function
-    # and newer functions for the rest of the periods
-    PERIOD_FUNC_MAP = {
-        'monthly': month_periods,
-        'daily': day_periods,
-        'hourly': hour_periods,
-        'weekly': week_periods,
-        'yearly': year_periods
-    }
-
     @property
     def start_at(self):
         if not hasattr(self, '_start_at'):
@@ -642,29 +630,6 @@ class DateRangeContextMixin(object):
         if self.ends_at:
             context.update({'ends_at': self.ends_at})
         return context
-
-    @property
-    def period_func(self):
-        # Returns the period function from the request with a default
-        # set to month_periods
-        period = self.request.GET.get('period')
-        return self.PERIOD_FUNC_MAP.get(period, month_periods)
-
-    @property
-    def num_periods(self):
-        if not hasattr(self, '_num_periods'):
-            num_periods = self.request.GET.get('num_periods', None)
-            try:
-                # Keeping the maximum value of num_periods to 100
-                if num_periods and 0 < int(num_periods) < 100:
-                    self._num_periods = int(num_periods)
-                else:
-                    self._num_periods = None
-            except ValueError:
-                # In case a string or other non-integer values are
-                # passed in
-                self._num_periods = None
-        return self._num_periods
 
 
 class InvoicablesMixin(OrganizationMixin):

--- a/saas/static/js/djaodjin-saas-vue.js
+++ b/saas/static/js/djaodjin-saas-vue.js
@@ -1504,7 +1504,7 @@ Vue.component('role-profile-list', {
             showRequested: false,
             params: {
                 role_status: "",
-                include_personal_profile: "1",
+                include_personal_profile: true,
             },
         }
     },
@@ -2269,7 +2269,7 @@ Vue.component('profile-update', {
         },
             convertToOrganization: function() {
               var vm = this;
-                vm.reqPost(vm.profile_url + `?convert-from-personal=1`, { full_name: vm.formFields.full_name },
+                vm.reqPost(vm.profile_url + `?convert_from_personal=1`, { full_name: vm.formFields.full_name },
                     function(resp) {
                         if (  resp.detail  ) {
                             vm.showMessages([resp.detail], "success");

--- a/saas/templates/saas/profile/roles/index.html
+++ b/saas/templates/saas/profile/roles/index.html
@@ -34,11 +34,11 @@
     </div>
     <!-- modals -->
     <hr />
-    <form class="form-horizontal" @submit.prevent="create">
+    <form class="form-horizontal" @submit.prevent="save">
       <h2>Add a new type of role</h2>
       <div>
         <label>Title</label>
-        <input v-model="role.title"
+        <input v-model="newItem.title"
                name="name" type="text" max-length="150"
                placeholder="ex: Sales associate"
                autofocus />


### PR DESCRIPTION
- `serializers.py':
  - Added 4 query parameter serializers.

- `api/billing.py`: 
  - Add and use query parameter serializer.

- `api/metrics.py`:
  - Replace GenericAPIView with APIView class
  - Add and use query parameter serializers

- `api/plans.py`:
  - Add and use query parameter serializers
  - Added swagger auto schema on get method

- `api/roles.py`:
  - Add and use query parameter serializers
  - Slightly modified POST request logic

 - `mixins.py`:
   - Removed period and num_periods' logics from DateRangeContextMixin since they're now applied in the PeriodSerializer

- `templates/saas/profile/roles/index.html`:
  - Updated variable names to match Vue component "roledescr-list"

- `saas/static/js/djaodjin-saas-vue.js`:
  - Minor updates 

Notes:
- Could add the swagger auto schema decorator on the rest of the get methods where it isn't used as well to show query parameters. Currently it's only added in api/plans.py/PlanListCreateAPIView
- In PR #283 I changed PeriodSerializer's period field to enumfield, so there might be a merge issue.