### PR TITLE
[Work-in-Progress] limit coupon use as one per profile

### DIFF
--- a/saas/models.py
+++ b/saas/models.py
@@ -812,6 +812,9 @@ class AbstractOrganization(models.Model):
                 subscription.save()
                 if cart_item:
                     cart_item.recorded = True
+                    if (cart_item.coupon and cart_item.coupon.once_per_user and
+                            user not in cart_item.coupon.uses.all()):
+                        cart_item.coupon.uses.add(user)
                     cart_item.save()
 
         # At this point we have gathered all the ``Organization``
@@ -3015,6 +3018,11 @@ class Coupon(models.Model):
         help_text=_("Number of times the coupon can be used"))
     extra = get_extra_field_class()(null=True,
         help_text=_("Extra meta data (can be stringify JSON)"))
+    once_per_user = models.BooleanField(default=False,
+        help_text=_("Flag indicating if the coupon can be used only once per user"))
+    uses = models.ManyToManyField(settings.AUTH_USER_MODEL,
+        related_name='uses', blank=True,
+        help_text=_("Users who have already redeemed this coupon"))
 
     class Meta:
         unique_together = ('organization', 'code')
@@ -3134,6 +3142,8 @@ class CartItemManager(models.Manager):
         for item in self.get_cart(user):
             redeemed = Coupon.objects.active(
                 item.plan.organization, coupon_code, at_time=at_time).first()
+            if redeemed and redeemed.once_per_user and user in redeemed.uses.all():
+                continue
             if redeemed and redeemed.is_valid(item.plan, at_time=at_time):
                 coupon_applied = True
                 item.coupon = redeemed


### PR DESCRIPTION
**Summary:**
- Add a "uses" ManyToManyField to keep track of a coupon's usage by users
- Validate the "redeem method" using this field
- Add users to this field in the "execute_order" method
- Works with abandoned carts, works with "redeem" function/APIview/"cart-periods/" page, works with coupon codes in the session. 

**Notes**:
- Uses users and not billing profiles.
- Didn't add the migrations file to the commit because there's another open PR #282  that has a migration that might get merged before this. 

**Other approaches tried**:
- Change get_cart_options
  - Uses billing profiles(ie. subscription.organization in the get_cart_options function) and filters for relevant Transactions where the coupon code is applied to keep track of usage. Could also use a ManyToManyField here and add to it in the execute_order function like done in this commit.
  - Issue:
    1. Visual mismatch on the /cart-periods/ page. Users can attempt to "redeem" coupons, and the page shows coupons as applied, although they aren't in effect. This occurs because CouponRedeemAPIView applies coupons to all eligible cart items for the requesting user, then afterwards get_cart_options sets the coupon to None.

- Changing CouponRedeemAPIView
  - Uses request.user, and filters for Transactions where the coupon is used OR uses a ManyToManyField in the coupon model to store users that have used a coupon
  - Issues:
    1. If we're using request.user but we want to track billing profiles, we can't properly filter for organizations since there's no "organization" passed into the view, and if we try to get attached_organizations that causes a mismatch when a user has multiple organizations.
    2. Doesn't work with abandoned carts, it would still count the coupon as used even if it weren't checked out