### PR TITLE
[Work-in-Progress] Endpoints to allow downloading reports as CSV (#288, #289, #290)

### DIFF
--- a/saas/api/billing.py
+++ b/saas/api/billing.py
@@ -38,6 +38,7 @@ from rest_framework import status
 from ..backends import ProcessorError
 from ..compat import gettext_lazy as _, is_authenticated, StringIO
 from ..docs import swagger_auto_schema, OpenAPIResponse
+from ..filters import SearchFilter
 from ..mixins import (BalanceAndCartMixin, CartMixin, InvoicablesMixin,
                       UserMixin)
 from ..models import CartItem, get_broker
@@ -628,8 +629,19 @@ class ActiveCartItemListCreateView(generics.ListCreateAPIView):
           }]
         }
     """
-    queryset = CartItem.objects.filter(recorded=False).order_by('user')
     serializer_class = CartItemSerializer
+
+    search_fields = (
+        'user__username',
+        'user__full_name',
+        'user__email',
+        'plan__slug',
+        'full_name'
+    )
+
+    filter_backends = (SearchFilter, )
+
+    queryset = CartItem.objects.filter(recorded=False).order_by('user')
 
     def get_serializer_class(self):
         if self.request.method.lower() in ['post']:

--- a/saas/api/metrics.py
+++ b/saas/api/metrics.py
@@ -935,26 +935,7 @@ class CouponUsesDownloadView(CSVWriterMixin, CartItemSmartListMixin,
 
         response, writer = self.get_csv_response('coupon_uses.csv')
 
-        if serialized_data:
-            headers = []
-            for key, value in serialized_data[0].items():
-                if isinstance(value, dict):
-                    for nested_key in value.keys():
-                        headers.append(f"{key}_{nested_key}")
-                else:
-                    headers.append(key)
-            writer.writerow(headers)
-
-            for item in serialized_data:
-                row = []
-                for key, value in item.items():
-                    if isinstance(value, dict):
-                        row.extend(value.values())
-                    else:
-                        row.append(value)
-                writer.writerow(row)
-        else:
-            writer.writerow(['No data available'])
+        self.write_csv_data(writer, serialized_data)
 
         return response
 
@@ -998,14 +979,7 @@ class LifetimeValueDownloadView(CSVWriterMixin, LifetimeValueMetricMixin, APIVie
 
         response, writer = self.get_csv_response('lifetime_value.csv')
 
-        if serialized_data:
-            headers = serialized_data[0].keys()
-            writer.writerow(headers)
-
-            for item in serialized_data:
-                writer.writerow(item.values())
-        else:
-            writer.writerow(['No data available'])
+        self.write_csv_data(writer, serialized_data)
 
         return response
 

--- a/saas/api/metrics.py
+++ b/saas/api/metrics.py
@@ -858,9 +858,7 @@ class BalancesDownloadView(CSVWriterMixin, MetricsMixin, APIView):
         headers = ['Date'] + [Transaction.INCOME, Transaction.BACKLOG, Transaction.RECEIVABLE]
         writer.writerow(headers)
 
-        for date, values in csv_data.items():
-            row = [date] + [values.get(header, 0) for header in headers[1:]]
-            writer.writerow(row)
+        self.write_csv_rows(writer, csv_data, headers)
 
         return response
 

--- a/saas/api/organizations.py
+++ b/saas/api/organizations.py
@@ -32,7 +32,6 @@ from rest_framework import parsers, status
 from rest_framework.generics import (CreateAPIView, ListAPIView,
     RetrieveUpdateDestroyAPIView)
 from rest_framework.response import Response
-from rest_framework.views import APIView
 
 from .serializers import (EngagedSubscriberSerializer, OrganizationSerializer,
     OrganizationDetailSerializer, OrganizationWithSubscriptionsSerializer,
@@ -43,7 +42,7 @@ from ..decorators import _valid_manager
 from ..filters import OrderingFilter, SearchFilter
 from ..mixins import (DateRangeContextMixin, OrganizationMixin,
     OrganizationSearchOrderListMixin, OrganizationSmartListMixin,
-    ProviderMixin, OrganizationDecorateMixin, CSVWriterMixin)
+    ProviderMixin, OrganizationDecorateMixin)
 from ..models import get_broker
 from ..utils import (build_absolute_uri, datetime_or_now,
     get_organization_model, get_role_model, get_picture_storage,
@@ -598,34 +597,3 @@ class UnengagedSubscribersAPIView(OrganizationSearchOrderListMixin,
         }
     """
     serializer_class = OrganizationSerializer
-
-class EngagedSubscribersDownloadView(EngagedSubscribersSmartListMixin,
-                                     EngagedSubscribersQuerysetMixin,
-                                     CSVWriterMixin, APIView):
-
-    def get(self, request, *args, **kwargs):
-        queryset = self.get_queryset()
-
-        serializer = EngagedSubscriberSerializer(queryset, many=True, context={'request': request})
-        serialized_data = serializer.data
-        response, writer = self.get_csv_response('engaged_subscribers.csv')
-
-        self.write_csv_data(writer, serialized_data)
-
-        return response
-
-
-class UnengagedSubscribersDownloadView(OrganizationSearchOrderListMixin,
-                                     UnengagedSubscribersQuerysetMixin,
-                                     CSVWriterMixin, APIView):
-
-    def get(self, request, *args, **kwargs):
-        queryset = self.get_queryset()
-
-        serializer = EngagedSubscriberSerializer(queryset, many=True, context={'request': request})
-        serialized_data = serializer.data
-        response, writer = self.get_csv_response('unengaged_subscribers.csv')
-
-        self.write_csv_data(writer, serialized_data)
-
-        return response

--- a/saas/mixins.py
+++ b/saas/mixins.py
@@ -1257,11 +1257,34 @@ class CSVWriterMixin:
         writer = csv.writer(response)
         return response, writer
 
+    # Used where the first column is dates
     def write_csv_rows(self, writer, csv_data, headers):
         for date, values in csv_data.items():
             row = [date] + [values.get(header, 0) for header in headers[1:]]
             writer.writerow(row)
 
+    def write_csv_data(self, writer, data):
+        if not data:
+            writer.writerow(['No data available'])
+            return
+
+        headers = []
+        for key, value in data[0].items():
+            if isinstance(value, dict):
+                for nested_key in value.keys():
+                    headers.append(f"{key}_{nested_key}")
+            else:
+                headers.append(key)
+        writer.writerow(headers)
+
+        for item in data:
+            row = []
+            for key, value in item.items():
+                if isinstance(value, dict):
+                    row.extend(value.values())
+                else:
+                    row.append(value)
+            writer.writerow(row)
 
 def _as_html_description(transaction_descr,
                          orig_organization=None, dest_organization=None,

--- a/saas/mixins.py
+++ b/saas/mixins.py
@@ -1263,6 +1263,9 @@ class BalancesDueMixin(DateRangeContextMixin, ProviderMixin):
 
 
 class MetricsDownloadMixin(object):
+
+    filter_backends = []
+
     def get_queryset(self):
         results, _ = self.get_data()
         consolidated_data = {}

--- a/saas/mixins.py
+++ b/saas/mixins.py
@@ -1221,6 +1221,13 @@ class BalancesDueMixin(DateRangeContextMixin, ProviderMixin):
         'full_name',
     )
 
+    ordering_fields = (
+        ('slug', 'Slug'),
+        ('full_name', 'Full Name'),
+        ('created_at', 'Created At')
+    )
+    ordering = ('slug',)
+
     filter_backends = (DateRangeFilter, SearchFilter, OrderingFilter)
 
     @property
@@ -1253,6 +1260,23 @@ class BalancesDueMixin(DateRangeContextMixin, ProviderMixin):
             else:
                 organization.balances = None
         return decorated_queryset
+
+
+class MetricsDownloadMixin(object):
+    def get_queryset(self):
+        results, _ = self.get_data()
+        consolidated_data = {}
+        for result in results:
+            for date_value in result['values']:
+                date_str = date_value[0]
+                if date_str not in consolidated_data:
+                    consolidated_data[date_str] = {
+                        'Date': date_str,
+                        **{heading: 0 for heading in self.headings if heading != 'Date'}
+                    }
+                consolidated_data[date_str][result['title']] = date_value[1]
+
+        return list(consolidated_data.values())
 
 
 def _as_html_description(transaction_descr,

--- a/saas/urls/api/provider/metrics.py
+++ b/saas/urls/api/provider/metrics.py
@@ -31,7 +31,9 @@ from ....api.federations import (FederatedSubscribersAPIView,
     SharedProfilesAPIView)
 from ....api.metrics import (BalancesAPIView, CouponUsesAPIView,
     CustomerMetricAPIView, LifetimeValueMetricAPIView, PlanMetricAPIView,
-    RevenueMetricAPIView, BalancesDueAPIView)
+    RevenueMetricAPIView, BalancesDueAPIView, BalancesDownloadView,
+    RevenueDownloadView, CouponUsesDownloadView, CustomerMetricDownloadView,
+    LifetimeValueDownloadView, PlanMetricDownloadView, BalancesDueDownloadView)
 from ....compat import path
 
 
@@ -69,4 +71,33 @@ urlpatterns = [
         settings.PROFILE_URL_KWARG,
         FederatedSubscribersAPIView.as_view(),
         name="saas_api_federated_subscribers"),
+
+    # Download metrics as CSV files
+    path('metrics/<slug:%s>/coupons/<slug:coupon>/download' %
+         settings.PROFILE_URL_KWARG,
+         CouponUsesDownloadView.as_view(),
+         name='saas_api_coupon_uses_download'),
+    path('metrics/<slug:%s>/balances/download' %
+         settings.PROFILE_URL_KWARG,
+         BalancesDownloadView.as_view(),
+         name='saas_api_balances_download'),
+    path('metrics/<slug:%s>/customers/download' %
+         settings.PROFILE_URL_KWARG,
+         CustomerMetricDownloadView.as_view(),
+         name='saas_api_customer_download'),
+    path('metrics/<slug:%s>/plans/download' %
+         settings.PROFILE_URL_KWARG,
+         PlanMetricDownloadView.as_view(),
+         name='saas_api_metrics_plans_download'),
+    path('metrics/cowork/funds/download',
+         RevenueDownloadView.as_view(),
+         name='saas_api_revenue_download'),
+    path('metrics/<slug:%s>/lifetimevalue/download' %
+         settings.PROFILE_URL_KWARG,
+         LifetimeValueDownloadView.as_view(),
+         name='saas_api_metrics_lifetimevalue_download'),
+    path('metrics/<slug:%s>/balances-due/download' %
+         settings.PROFILE_URL_KWARG,
+         BalancesDueDownloadView.as_view(),
+         name='saas_api_metrics_balances_due_download'),
 ]

--- a/saas/urls/api/provider/metrics.py
+++ b/saas/urls/api/provider/metrics.py
@@ -31,9 +31,7 @@ from ....api.federations import (FederatedSubscribersAPIView,
     SharedProfilesAPIView)
 from ....api.metrics import (BalancesAPIView, CouponUsesAPIView,
     CustomerMetricAPIView, LifetimeValueMetricAPIView, PlanMetricAPIView,
-    RevenueMetricAPIView, BalancesDueAPIView, BalancesDownloadView,
-    RevenueDownloadView, CouponUsesDownloadView, CustomerMetricDownloadView,
-    LifetimeValueDownloadView, PlanMetricDownloadView, BalancesDueDownloadView)
+    RevenueMetricAPIView, BalancesDueAPIView)
 from ....compat import path
 
 
@@ -70,34 +68,5 @@ urlpatterns = [
     path('metrics/<slug:%s>/federated' %
         settings.PROFILE_URL_KWARG,
         FederatedSubscribersAPIView.as_view(),
-        name="saas_api_federated_subscribers"),
-
-    # Download metrics as CSV files
-    path('metrics/<slug:%s>/coupons/<slug:coupon>/download' %
-         settings.PROFILE_URL_KWARG,
-         CouponUsesDownloadView.as_view(),
-         name='saas_api_coupon_uses_download'),
-    path('metrics/<slug:%s>/balances/download' %
-         settings.PROFILE_URL_KWARG,
-         BalancesDownloadView.as_view(),
-         name='saas_api_balances_download'),
-    path('metrics/<slug:%s>/customers/download' %
-         settings.PROFILE_URL_KWARG,
-         CustomerMetricDownloadView.as_view(),
-         name='saas_api_customer_download'),
-    path('metrics/<slug:%s>/plans/download' %
-         settings.PROFILE_URL_KWARG,
-         PlanMetricDownloadView.as_view(),
-         name='saas_api_metrics_plans_download'),
-    path('metrics/cowork/funds/download',
-         RevenueDownloadView.as_view(),
-         name='saas_api_revenue_download'),
-    path('metrics/<slug:%s>/lifetimevalue/download' %
-         settings.PROFILE_URL_KWARG,
-         LifetimeValueDownloadView.as_view(),
-         name='saas_api_metrics_lifetimevalue_download'),
-    path('metrics/<slug:%s>/balances-due/download' %
-         settings.PROFILE_URL_KWARG,
-         BalancesDueDownloadView.as_view(),
-         name='saas_api_metrics_balances_due_download'),
+        name="saas_api_federated_subscribers")
 ]

--- a/saas/urls/api/provider/subscribers.py
+++ b/saas/urls/api/provider/subscribers.py
@@ -28,8 +28,7 @@ API URLs for a provider subcribers.
 
 from .... import settings
 from ....api.organizations import (EngagedSubscribersAPIView,
-    ProviderAccessiblesAPIView, UnengagedSubscribersAPIView,
-    EngagedSubscribersDownloadView, UnengagedSubscribersDownloadView)
+    ProviderAccessiblesAPIView, UnengagedSubscribersAPIView)
 from ....api.subscriptions import (ActiveSubscribersAPIView,
     AllSubscribersAPIView, ChurnedSubscribersAPIView, PlanAllSubscribersAPIView,
     PlanActiveSubscribersAPIView, PlanChurnedSubscribersAPIView,
@@ -83,14 +82,5 @@ urlpatterns = [
         settings.PROFILE_URL_KWARG,
         PlanActiveSubscribersAPIView.as_view(),
         name='saas_api_plan_subscribers'),
-
-    path('profile/<slug:%s>/subscribers/engaged/download' %
-        settings.PROFILE_URL_KWARG,
-        EngagedSubscribersDownloadView.as_view(),
-        name='saas_api_engaged_subscribers_download'),
-    path('profile/<slug:%s>/subscribers/unengaged/download' %
-        settings.PROFILE_URL_KWARG,
-        UnengagedSubscribersDownloadView.as_view(),
-        name='saas_api_unengaged_subscribers_download'),
 
 ]

--- a/saas/urls/api/provider/subscribers.py
+++ b/saas/urls/api/provider/subscribers.py
@@ -28,7 +28,8 @@ API URLs for a provider subcribers.
 
 from .... import settings
 from ....api.organizations import (EngagedSubscribersAPIView,
-    ProviderAccessiblesAPIView, UnengagedSubscribersAPIView)
+    ProviderAccessiblesAPIView, UnengagedSubscribersAPIView,
+    EngagedSubscribersDownloadView, UnengagedSubscribersDownloadView)
 from ....api.subscriptions import (ActiveSubscribersAPIView,
     AllSubscribersAPIView, ChurnedSubscribersAPIView, PlanAllSubscribersAPIView,
     PlanActiveSubscribersAPIView, PlanChurnedSubscribersAPIView,
@@ -82,4 +83,14 @@ urlpatterns = [
         settings.PROFILE_URL_KWARG,
         PlanActiveSubscribersAPIView.as_view(),
         name='saas_api_plan_subscribers'),
+
+    path('profile/<slug:%s>/subscribers/engaged/download' %
+        settings.PROFILE_URL_KWARG,
+        EngagedSubscribersDownloadView.as_view(),
+        name='saas_api_engaged_subscribers_download'),
+    path('profile/<slug:%s>/subscribers/unengaged/download' %
+        settings.PROFILE_URL_KWARG,
+        UnengagedSubscribersDownloadView.as_view(),
+        name='saas_api_unengaged_subscribers_download'),
+
 ]

--- a/saas/urls/api/provider/subscribers.py
+++ b/saas/urls/api/provider/subscribers.py
@@ -82,5 +82,4 @@ urlpatterns = [
         settings.PROFILE_URL_KWARG,
         PlanActiveSubscribersAPIView.as_view(),
         name='saas_api_plan_subscribers'),
-
 ]

--- a/saas/urls/views/provider/metrics.py
+++ b/saas/urls/views/provider/metrics.py
@@ -28,7 +28,9 @@ Urls to metrics
 
 from .... import settings
 from ....compat import path
-from ....views.download import CartItemDownloadView
+from ....views.download import (CartItemDownloadView, BalancesDueDownloadView, BalancesMetricsDownloadView,
+                                CustomerMetricsDownloadView, RevenueMetricsDownloadView,
+                                CouponUsesDownloadView)
 from ....views.profile import DashboardView
 from ....views.metrics import (SubscribersActivityView,
     CouponMetricsView, LifeTimeValueDownloadView,
@@ -70,8 +72,26 @@ urlpatterns = [
         settings.PROFILE_URL_KWARG,
         SubscribersActivityView.as_view(),
         name='saas_subscribers_activity'),
-    path('metrics/<slug:%s>/balances-due' %
+    path('metrics/<slug:%s>/balances-due/' %
          settings.PROFILE_URL_KWARG,
          BalancesDueView.as_view(),
-         name='saas_metrics_balances_due')
+         name='saas_metrics_balances_due'),
+
+    # URLs to download metrics as CSVs.
+    path('metrics/<slug:%s>/balances-due/download'
+         % settings.PROFILE_URL_KWARG,
+         BalancesDueDownloadView.as_view(),
+         name='saas_metrics_balances_due_download'),
+    path('metrics/<slug:%s>/balances/download'
+         % settings.PROFILE_URL_KWARG,
+         BalancesMetricsDownloadView.as_view(),
+         name='saas_metrics_balances_download'),
+    path('metrics/<slug:%s>/customers/download'
+         % settings.PROFILE_URL_KWARG,
+         CustomerMetricsDownloadView.as_view(),
+         name='saas_metrics_customers_download'),
+    path('metrics/<slug:%s>/funds/download'
+         % settings.PROFILE_URL_KWARG,
+        RevenueMetricsDownloadView.as_view(),
+         name='saas_metrics_revenue_download'),
 ]

--- a/saas/urls/views/provider/metrics.py
+++ b/saas/urls/views/provider/metrics.py
@@ -29,8 +29,7 @@ Urls to metrics
 from .... import settings
 from ....compat import path
 from ....views.download import (CartItemDownloadView, BalancesDueDownloadView, BalancesMetricsDownloadView,
-                                CustomerMetricsDownloadView, RevenueMetricsDownloadView,
-                                CouponUsesDownloadView)
+                                CustomerMetricsDownloadView, RevenueMetricsDownloadView)
 from ....views.profile import DashboardView
 from ....views.metrics import (SubscribersActivityView,
     CouponMetricsView, LifeTimeValueDownloadView,
@@ -77,7 +76,7 @@ urlpatterns = [
          BalancesDueView.as_view(),
          name='saas_metrics_balances_due'),
 
-    # URLs to download metrics as CSVs.
+    # URLs to download metrics as .csv
     path('metrics/<slug:%s>/balances-due/download'
          % settings.PROFILE_URL_KWARG,
          BalancesDueDownloadView.as_view(),

--- a/saas/urls/views/provider/profile.py
+++ b/saas/urls/views/provider/profile.py
@@ -65,8 +65,6 @@ urlpatterns = [
     path('profile/<slug:%s>/subscribers/' %
         settings.PROFILE_URL_KWARG,
         SubscriberListView.as_view(), name='saas_subscriber_list'),
-
-    # CSV Download views
     path('profile/<slug:%s>/plans/download'
          % settings.PROFILE_URL_KWARG,
          PlanMetricsDownloadView.as_view(),

--- a/saas/urls/views/provider/profile.py
+++ b/saas/urls/views/provider/profile.py
@@ -29,7 +29,8 @@ URLs related to provider bank account information.
 from .... import settings
 from ....compat import path, re_path
 from ....views.download import (ActiveSubscriptionDownloadView,
-    ChurnedSubscriptionDownloadView)
+    ChurnedSubscriptionDownloadView, PlanMetricsDownloadView,
+    EngagedSubscribersDownloadView, UnengagedSubscribersDownloadView)
 from ....views.optins import SubscriptionRequestAcceptView
 from ....views.plans import PlanCreateView, PlanUpdateView, PlanListView
 from ....views.profile import SubscriberListView, PlanSubscribersListView
@@ -64,4 +65,18 @@ urlpatterns = [
     path('profile/<slug:%s>/subscribers/' %
         settings.PROFILE_URL_KWARG,
         SubscriberListView.as_view(), name='saas_subscriber_list'),
+
+    # CSV Download views
+    path('profile/<slug:%s>/plans/download'
+         % settings.PROFILE_URL_KWARG,
+         PlanMetricsDownloadView.as_view(),
+         name='saas_metrics_plans_download'),
+    path('profile/<slug:%s>/subscribers/engaged/download' %
+         settings.PROFILE_URL_KWARG,
+         EngagedSubscribersDownloadView.as_view(),
+         name='saas_engaged_subscribers_download'),
+    path('profile/<slug:%s>/subscribers/unengaged/download' %
+         settings.PROFILE_URL_KWARG,
+         UnengagedSubscribersDownloadView.as_view(),
+         name='saas_unengaged_subscribers_download'),
 ]

--- a/saas/views/download.py
+++ b/saas/views/download.py
@@ -59,6 +59,7 @@ from ..mixins import (CartItemSmartListMixin, ProviderMixin,
 from ..models import BalanceLine, CartItem, Coupon
 from ..utils import datetime_or_now, convert_dates_to_utc
 
+
 class CSVDownloadView(View):
 
     basename = 'download'
@@ -431,7 +432,6 @@ class TransferDownloadView(SmartTransactionListMixin,
 class BalancesMetricsDownloadView(MetricsDownloadMixin, BalancesMetricsMixin,
                                   CSVDownloadView):
     basename = 'balancesmetrics'
-    filter_backends = []
 
     headings = [
         'Date',
@@ -451,7 +451,6 @@ class RevenueMetricsDownloadView(MetricsDownloadMixin, RevenueMetricsMixin,
                                  CSVDownloadView):
 
     basename = 'revenuemetrics'
-    filter_backends = []
 
     headings = [
         'Date',
@@ -473,7 +472,6 @@ class CustomerMetricsDownloadView(MetricsDownloadMixin, CustomerMetricsMixin,
                                   CSVDownloadView):
 
     basename = 'customermetrics'
-    filter_backends = []
 
     headings = [
         'Date',
@@ -494,7 +492,6 @@ class PlanMetricsDownloadView(MetricsDownloadMixin, PlanMetricsMixin,
                               CSVDownloadView):
 
     basename = 'planmetrics'
-    filter_backends = []
 
     @property
     def plans(self):

--- a/saas/views/download.py
+++ b/saas/views/download.py
@@ -584,43 +584,7 @@ class PlanMetricsDownloadView(CSVDownloadView, PlanMetricsMixin):
         return super().get(request, *args, **kwargs)
 
 
-class CouponUsesDownloadView(CSVDownloadView, CartItemSmartListMixin,
-                                CouponUsesQuerysetMixin, CouponMixin):
-    basename = 'coupon_uses'
-
-    headings = [
-        'Created At',
-        'User',
-        'Claim Code',
-        'Plan',
-        'Option',
-        'Use',
-        'Quantity',
-        'Sync On',
-    ]
-
-    def get_headings(self):
-        return self.headings
-
-    def get_queryset(self):
-        return super(CouponUsesQuerysetMixin, self).get_queryset()
-
-    def queryrow_to_columns(self, record):
-        row = [
-            getattr(record, 'created_at', ''),
-            getattr(record, 'user', ''),
-            getattr(record, 'claim_code', ''),
-            getattr(record, 'plan', ''),
-            getattr(record, 'option', ''),
-            getattr(record, 'use', ''),
-            getattr(record, 'quantity', 0),
-            getattr(record, 'sync_on', ''),
-        ]
-
-        return [self.encode(item) for item in row]
-
-
-class BalancesDueDownloadView(CSVDownloadView, BalancesDueMixin):
+class BalancesDueDownloadView(BalancesDueMixin, CSVDownloadView):
     basename = 'balances_due'
 
     def get_headings(self):
@@ -654,8 +618,9 @@ class BalancesDueDownloadView(CSVDownloadView, BalancesDueMixin):
         return currency_set
 
     def get_queryset(self):
-        queryset = BalancesDueMixin.get_queryset(self)
-        decorated_queryset = BalancesDueMixin.decorate_queryset(self, queryset)
+        queryset = super(BalancesDueDownloadView, self).get_queryset()
+        decorated_queryset = super(BalancesDueDownloadView, self).decorate_queryset(
+            queryset)
         # Using a serializer to get type, credentials
         serializer = BalancesDueSerializer(decorated_queryset, many=True)
         return serializer.data


### PR DESCRIPTION
Added endpoints to allow downloading reports as CSV.

Some reports need their data to be slightly transformed, eg. balances-due view requires accounting for different units, the coupon_uses view requires accounting for nested values.


Notes:
- Works with query parameters.
- Tried the content-type approach with the request header sending Accept:text/csv but that didn't work with DRF, I think it could work with a custom CSV renderer.